### PR TITLE
Bump sqlx connection pool size to 15

### DIFF
--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -19,7 +19,7 @@ pub async fn connect(url: &str) -> Result<Pool<Postgres>, errors::ExtensionRegis
     let options = conn_options(url)?;
     let pgp = PgPoolOptions::new()
         .acquire_timeout(std::time::Duration::from_secs(10))
-        .max_connections(5)
+        .max_connections(15)
         .connect_with(options)
         .await?;
     Ok(pgp)


### PR DESCRIPTION
We're seeing connection pool issues with our new Trunk UI. @karlmorand and I found that increasing the connection pool is a viable solution. This PR bumps the `sqlx` connection pool to 15.