### PR TITLE
Less margin on categories

### DIFF
--- a/ui/src/Components/Categories/categories.module.scss
+++ b/ui/src/Components/Categories/categories.module.scss
@@ -8,6 +8,7 @@
   height: 100%;
   margin: 0 $spacing-7xl;
   align-self: flex-start;
+  padding-top: $spacing-m/2;
   padding-bottom: $spacing-l;
 }
 @media screen and (max-width: 1024px) {

--- a/ui/src/Components/Categories/categories.module.scss
+++ b/ui/src/Components/Categories/categories.module.scss
@@ -17,7 +17,7 @@
 }
 
 .listItem {
-  margin: $spacing-m 0;
+  margin: $spacing-m/2 0;
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/ui/src/Components/Categories/categories.module.scss
+++ b/ui/src/Components/Categories/categories.module.scss
@@ -2,13 +2,13 @@
 .container {
   display: flex;
   flex-direction: column;
-  width: 220px;
+  width: 250px;
   position: sticky;
   top: $spacing-6xl;
   height: 100%;
-  margin: 0 $spacing-7xl;
+  margin: 0 $spacing-5xl;
   align-self: flex-start;
-  padding-top: $spacing-m/2;
+  padding-top: $spacing-s;
   padding-bottom: $spacing-l;
 }
 @media screen and (max-width: 1024px) {
@@ -18,7 +18,7 @@
 }
 
 .listItem {
-  margin: $spacing-m/2 0;
+  margin: $spacing-s 0;
   display: flex;
   flex-direction: row;
   justify-content: space-between;


### PR DESCRIPTION
On my computer, categories run down the entire side of the site, and it's not clear if it's a UI bug that I can't scroll to see more. This PR reduces the spacing between category labels on the left, which is a user experience improvement from my perspective.

Also widens the column slightly so no categories wrap.