### PR TITLE
modify Trunk.toml to remove address_standardizer_data_us

### DIFF
--- a/contrib/address_standardizer_3/Trunk.toml
+++ b/contrib/address_standardizer_3/Trunk.toml
@@ -15,7 +15,6 @@ dockerfile = "Dockerfile"
 install_command = """
     cd postgis-3.3.3/extensions/address_standardizer && make install
     set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
-
+    find /usr/share/postgresql/15/extension -type f -iname '*data*' -exec rm {} +
+    find /usr/lib/postgresql/15/lib -type f -iname '*data*' -exec rm {} +
+"""

--- a/contrib/address_standardizer_data_us/Dockerfile
+++ b/contrib/address_standardizer_data_us/Dockerfile
@@ -1,0 +1,28 @@
+ARG PG_VERSION=15
+FROM quay.io/coredb/c-builder:pg${PG_VERSION}
+USER root
+
+RUN apt-get update && apt-get install -y \
+ build-essential \
+ libreadline-dev \
+ zlib1g-dev \
+ flex \
+ bison \
+ libxml2-dev \
+ libxslt-dev \
+ libssl-dev \
+ libxml2-utils \
+ xsltproc \
+ ccache \
+ libgdal-dev \
+ libgeos-dev \
+ osm2pgsql \
+ libprotobuf-c-dev \
+ protobuf-c-compiler
+
+RUN wget https://download.osgeo.org/postgis/source/postgis-3.3.3.tar.gz && \ 
+	tar xvf postgis-3.3.3.tar.gz && \
+	cd postgis-3.3.3 && \
+	./configure && \
+	cd extensions/address_standardizer && \
+	make

--- a/contrib/address_standardizer_data_us/Trunk.toml
+++ b/contrib/address_standardizer_data_us/Trunk.toml
@@ -1,0 +1,20 @@
+[extension]
+name = "address_standardizer_data_us"
+version = "3.3.3"
+repository = "https://github.com/postgis/postgis"
+license = "GPL-2.0"
+description = "The packaged extension address_standardizer_data_us contains data for standardizing US addresses."
+homepage = "http://postgis.net/"
+documentation = "https://postgis.net/docs/Extras.html"
+categories = ["data_transformations"]
+
+[build]
+postgres_version = "15"
+platform = "linux/amd64"
+dockerfile = "Dockerfile"
+install_command = """
+    cd postgis-3.3.3/extensions/address_standardizer && make install
+    set -x
+    find /usr/share/postgresql/15/extension -type f -iname '*standardizer--*' -exec rm {} +
+    find /usr/share/postgresql/15/extension -type f -iname '*standardizer.*' -exec rm {} +
+"""


### PR DESCRIPTION
Modify Trunk.toml to remove address_standardizer_data_us files from tar.gz, allowing for separate extension, `address_standardizer_data_us`