### PR TITLE
ui: be stricter with static prop build errors

### DIFF
--- a/ui/src/pages/extensions/[ext]/index.tsx
+++ b/ui/src/pages/extensions/[ext]/index.tsx
@@ -168,8 +168,7 @@ export async function getStaticProps({ params }: { params: { ext: string } }) {
       const extRes = await fetch(`https://registry.pgtrunk.io/extensions/detail/${params.ext}`);
       extension = await extRes.json();
     } catch (error) {
-      console.log("********** ERROR FETCHING DETAIL FROM TRUNK **********", params.ext);
-      extension = null;
+      return Promise.reject(Error(`Failed to fetch '${params.ext}' from Trunk: ${error}`));
     }
     const latestVersion: Extension = extension ? extension[extension.length - 1] : null;
     if (extension && latestVersion?.repository && latestVersion.repository.includes("github.com")) {
@@ -192,8 +191,7 @@ export async function getStaticProps({ params }: { params: { ext: string } }) {
         const repoJson = repoRes ? await repoRes.json() : null;
         repoDescription = repoJson?.description ?? "";
       } catch (error: any) {
-        console.log("********** ERROR FETCHING REPO **********", error.message, repo);
-        repoRes = null;
+        return Promise.reject(Error(`Failed to fetch repository '${repo}' from GitHub: ${error.message}`));
       }
 
       try {
@@ -204,8 +202,7 @@ export async function getStaticProps({ params }: { params: { ext: string } }) {
         });
         readmeJson = await readmeRes.json();
       } catch (error: any) {
-        readme = "";
-        console.log("********** README FETCH ERROR **********", error.message, githubReadmeUrl);
+        return Promise.reject(Error(`Failed to fetch README at '${githubReadmeUrl}': ${error.message}`));
       }
 
       try {
@@ -222,7 +219,7 @@ export async function getStaticProps({ params }: { params: { ext: string } }) {
             readme = readmeJson ? Buffer.from(readmeJson.content, "base64").toString("utf-8") : "";
           }
         } catch (error: any) {
-          console.log("********** README PARSE ERROR **********", error.message, githubReadmeUrl);
+          return Promise.reject(Error(`Failed to parse README at '${githubReadmeUrl}': ${error.message}`));
         }
       }
     }


### PR DESCRIPTION
When fetching extension info & READMEs, fail to compile if anything goes wrong

This is useful for us to know of a problem with our registry or GH API config early on and ensure that http://pgt.dev is always in a great shape. With this PR I believe the following page can no longer be rendered:

![image](https://github.com/tembo-io/trunk/assets/36349314/39983b4c-2a58-4dd9-a721-3d1c31d650ba)
  