### PR TITLE
Trunk perf

### DIFF
--- a/registry/src/errors.rs
+++ b/registry/src/errors.rs
@@ -5,6 +5,7 @@ use actix_web::http::header::ToStrError;
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::operation::put_object::PutObjectError;
 use std::str::Utf8Error;
+use std::string::FromUtf8Error;
 use thiserror::Error;
 use url::ParseError;
 
@@ -65,4 +66,10 @@ pub enum ExtensionRegistryError {
 
     #[error("to str error: {0}")]
     ToStrError(#[from] ToStrError),
+
+    #[error("failed to convert bytes to UTF-8: {0}")]
+    Utf8Error(#[from] FromUtf8Error),
+
+    #[error("received malformed JWT")]
+    MalformedJwt,
 }

--- a/registry/src/routes/token.rs
+++ b/registry/src/routes/token.rs
@@ -41,7 +41,7 @@ pub async fn new_token(
             ",
         claims.sub,
         claims.userName,
-        token_sha
+        &token_sha
     )
     .execute(&mut tx)
     .await?;

--- a/registry/src/routes/token.rs
+++ b/registry/src/routes/token.rs
@@ -57,9 +57,11 @@ fn b64_decode(b64_encoded: &str) -> Result<String, ExtensionRegistryError> {
 }
 
 pub fn decode_claims(jwt: &str) -> Result<Claims, ExtensionRegistryError> {
-    let parts: Vec<&str> = jwt.split('.').collect();
-    let payload = parts[1];
+    let mut parts = jwt.split('.');
+    let payload = parts.nth(1).ok_or(ExtensionRegistryError::MalformedJwt)?;
+
     let decoded_payload = b64_decode(payload)?;
     let claims: Claims = serde_json::from_str(&decoded_payload)?;
+
     Ok(claims)
 }

--- a/registry/src/routes/token.rs
+++ b/registry/src/routes/token.rs
@@ -53,7 +53,7 @@ fn b64_decode(b64_encoded: &str) -> Result<String, ExtensionRegistryError> {
     let bytes = general_purpose::URL_SAFE_NO_PAD
         .decode(b64_encoded)
         .map_err(|_| ExtensionRegistryError::TokenError("invalid base64".to_owned()))?;
-    Ok(std::str::from_utf8(&bytes)?.to_owned())
+    Ok(String::from_utf8(bytes)?)
 }
 
 pub fn decode_claims(jwt: &str) -> Result<Claims, ExtensionRegistryError> {

--- a/registry/src/token.rs
+++ b/registry/src/token.rs
@@ -10,7 +10,7 @@ use sqlx::{Pool, Postgres};
 const TOKEN_LENGTH: usize = 32;
 
 // Generate API token
-pub fn generate_token() -> (String, Vec<u8>) {
+pub fn generate_token() -> (String, [u8; 32]) {
     let plaintext = generate_secure_alphanumeric_string(TOKEN_LENGTH);
     let sha256 = hash(&plaintext);
     (plaintext, sha256)
@@ -21,7 +21,12 @@ pub async fn validate_token(
     token: &HeaderValue,
     conn: Data<Pool<Postgres>>,
 ) -> Result<UserInfo, ExtensionRegistryError> {
-    check_token_input(token.to_str()?)?;
+    // Ensure header is valid UTF-8
+    let token = token.to_str()?;
+    check_token_input(token)?;
+
+    let token_digest = hash(token);
+
     let mut tx = conn.begin().await?;
     // Check if token exists
     let token_exists = sqlx::query!(
@@ -29,10 +34,11 @@ pub async fn validate_token(
                 FROM api_tokens
                 WHERE
                     token = $1",
-        hash(token.to_str()?),
+        &token_digest,
     )
     .fetch_optional(&mut tx)
     .await?;
+
     match token_exists {
         Some(_token_exists) => {
             // Check if token has an associated user ID
@@ -41,20 +47,22 @@ pub async fn validate_token(
                 FROM api_tokens
                 WHERE
                     token = $1",
-                hash(token.to_str()?),
+                &token_digest,
             )
             .fetch_one(&mut tx)
             .await?;
+
             // TODO(ianstanton) we can perform this in a single query
             let uname = sqlx::query!(
                 "SELECT user_name
                 FROM api_tokens
                 WHERE
                     token = $1",
-                hash(token.to_str()?),
+                &token_digest,
             )
             .fetch_one(&mut tx)
             .await?;
+
             let user = UserInfo {
                 user_id: uid.user_id.unwrap(),
                 user_name: uname.user_name,
@@ -63,6 +71,7 @@ pub async fn validate_token(
         }
         None => {
             error!("invalid token: API token does not exist");
+
             Err(ExtensionRegistryError::TokenError(
                 "invalid token: API token does not exist".to_owned(),
             ))
@@ -70,10 +79,12 @@ pub async fn validate_token(
     }
 }
 
-fn hash(plaintext: &str) -> Vec<u8> {
-    sha2::Sha256::digest(plaintext.as_bytes())
+fn hash<B: AsRef<[u8]>>(to_digest: B) -> [u8; 32] {
+    // Safety: this expect must not fail since Sha256::digest returns a GenericArray<u8, 32>
+    sha2::Sha256::digest(to_digest)
         .as_slice()
-        .to_vec()
+        .try_into()
+        .expect("SHA-256 must be 32 bytes")
 }
 
 fn generate_secure_alphanumeric_string(len: usize) -> String {
@@ -86,7 +97,7 @@ fn generate_secure_alphanumeric_string(len: usize) -> String {
 }
 
 pub fn check_token_input(input: &str) -> Result<(), ExtensionRegistryError> {
-    let valid = input.as_bytes().iter().all(|&c| c.is_ascii_alphanumeric());
+    let valid = input.as_bytes().iter().all(u8::is_ascii_alphanumeric);
     match valid {
         true => Ok(()),
         false => Err(ExtensionRegistryError::TokenError(
@@ -113,4 +124,52 @@ fn test_check_token() {
     let valid = "vBAfmrAa228VPYUnpPv5NdDWFXfkyh6I";
     let valid_result = check_token_input(valid);
     assert!(matches!(valid_result, Ok(())))
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn digests_sha256() {
+        // Ref on EMPTY & NIST.1: https://www.dlitz.net/crypto/shad256-test-vectors/
+
+        assert_eq!(
+            // "EMPTY" test vector
+            super::hash([]),
+            [
+                0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f,
+                0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b,
+                0x78, 0x52, 0xb8, 0x55,
+            ]
+        );
+
+        assert_eq!(
+            // "NIST.1" test vector
+            super::hash("abc"),
+            [
+                0xba, 0x78, 0x16, 0xbf, 0x8f, 0x1, 0xcf, 0xea, 0x41, 0x41, 0x40, 0xde, 0x5d, 0xae,
+                0x22, 0x23, 0xb0, 0x3, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c, 0xb4, 0x10, 0xff, 0x61,
+                0xf2, 0x0, 0x15, 0xad
+            ]
+        );
+
+        assert_eq!(
+            // Test case from Google Nearby (https://developers.google.com/nearby/fast-pair/specifications/appendix/testcases)
+            super::hash([0x11, 0x22, 0x33, 0x44, 0x55, 0x66]),
+            [
+                0xBB, 0x00, 0x0D, 0xDD, 0x92, 0xA0, 0xA2, 0xA3, 0x46, 0xF0, 0xB5, 0x31, 0xF2, 0x78,
+                0xAF, 0x06, 0xE3, 0x70, 0xF8, 0x69, 0x32, 0xCC, 0xAF, 0xCC, 0xC8, 0x92, 0xD6, 0x8D,
+                0x35, 0x0F, 0x80, 0xF8
+            ]
+        );
+
+        assert_eq!(
+            super::hash("Hello, world!"),
+            [
+                0x31, 0x5f, 0x5b, 0xdb, 0x76, 0xd0, 0x78, 0xc4, 0x3b, 0x8a, 0xc0, 0x6, 0x4e, 0x4a,
+                0x1, 0x64, 0x61, 0x2b, 0x1f, 0xce, 0x77, 0xc8, 0x69, 0x34, 0x5b, 0xfc, 0x94, 0xc7,
+                0x58, 0x94, 0xed, 0xd3
+            ]
+        );
+    }
 }


### PR DESCRIPTION
Silly little latency-related changes to the token-related functionality of trunk

* ec417c285ac5808c2ab58493833232f3a0c61f3b
    * Reuse the b64-decoded buffer
 * a1ac9017ac9177d13d4206aa13848029341b69d3
    * Parses through the JWT lazily
 * dc51ba8b7ae401af5dd15dd51bcc535ae070f612
    * Given we know a SHA-256 is always 32 bytes-long (256 bits), I switch over to storing these digests on the stack
 