### PR TITLE
Update postgres build release to match tag

### DIFF
--- a/contrib/adminpack/Dockerfile
+++ b/contrib/adminpack/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/adminpack && \
 	make

--- a/contrib/auth_delay/Dockerfile
+++ b/contrib/auth_delay/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/auth_delay && \
 	make

--- a/contrib/auto_explain/Dockerfile
+++ b/contrib/auto_explain/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/auto_explain && \
 	make

--- a/contrib/autoinc/Dockerfile
+++ b/contrib/autoinc/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-    git fetch origin REL_${PG_VERSION}_STABLE && \
-    git checkout REL_${PG_VERSION}_STABLE && \
+    git fetch origin ${PG_RELEASE} && \
+    git checkout ${PG_RELEASE} && \
     ./configure && \
     cd contrib/spi && \
     make

--- a/contrib/basebackup_to_shell/Dockerfile
+++ b/contrib/basebackup_to_shell/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/basebackup_to_shell && \
 	make

--- a/contrib/basic_archive/Dockerfile
+++ b/contrib/basic_archive/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/basic_archive && \
 	make

--- a/contrib/bloom/Dockerfile
+++ b/contrib/bloom/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/bloom && \
 	make

--- a/contrib/bool_plperl/Dockerfile
+++ b/contrib/bool_plperl/Dockerfile
@@ -20,11 +20,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure --with-perl && \
 	cd contrib/bool_plperl && \
 	make

--- a/contrib/btree_gin/Dockerfile
+++ b/contrib/btree_gin/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/btree_gin && \
 	make

--- a/contrib/btree_gist/Dockerfile
+++ b/contrib/btree_gist/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/btree_gist && \
 	make

--- a/contrib/citext/Dockerfile
+++ b/contrib/citext/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/citext && \
 	make

--- a/contrib/cube/Dockerfile
+++ b/contrib/cube/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/cube && \
 	make

--- a/contrib/dblink/Dockerfile
+++ b/contrib/dblink/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/dblink && \
 	make

--- a/contrib/dict_int/Dockerfile
+++ b/contrib/dict_int/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/dict_int && \
 	make

--- a/contrib/dict_xsyn/Dockerfile
+++ b/contrib/dict_xsyn/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/dict_xsyn && \
 	make

--- a/contrib/earthdistance/Dockerfile
+++ b/contrib/earthdistance/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/earthdistance && \
 	make

--- a/contrib/file_fdw/Dockerfile
+++ b/contrib/file_fdw/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/file_fdw && \
 	make

--- a/contrib/fuzzystrmatch/Dockerfile
+++ b/contrib/fuzzystrmatch/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/fuzzystrmatch && \
 	make

--- a/contrib/hstore/Dockerfile
+++ b/contrib/hstore/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/hstore && \
 	make

--- a/contrib/hstore_plperl/Dockerfile
+++ b/contrib/hstore_plperl/Dockerfile
@@ -20,11 +20,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure --with-perl && \
 	cd contrib/hstore_plperl && \
 	make

--- a/contrib/hstore_plpython/Dockerfile
+++ b/contrib/hstore_plpython/Dockerfile
@@ -19,11 +19,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure --with-python && \
 	cd contrib/hstore_plpython && \
 	make

--- a/contrib/insert_username/Dockerfile
+++ b/contrib/insert_username/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-    git fetch origin REL_${PG_VERSION}_STABLE && \
-    git checkout REL_${PG_VERSION}_STABLE && \
+    git fetch origin ${PG_RELEASE} && \
+    git checkout ${PG_RELEASE} && \
     ./configure && \
     cd contrib/spi && \
     make

--- a/contrib/intagg/Dockerfile
+++ b/contrib/intagg/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/intagg && \
 	make

--- a/contrib/intarray/Dockerfile
+++ b/contrib/intarray/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/intarray && \
 	make

--- a/contrib/isn/Dockerfile
+++ b/contrib/isn/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/isn && \
 	make

--- a/contrib/jsonb_plperl/Dockerfile
+++ b/contrib/jsonb_plperl/Dockerfile
@@ -20,11 +20,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure --with-perl && \
 	cd contrib/jsonb_plperl && \
 	make

--- a/contrib/jsonb_plpython/Dockerfile
+++ b/contrib/jsonb_plpython/Dockerfile
@@ -19,11 +19,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure --with-python && \
 	cd contrib/jsonb_plpython && \
 	make

--- a/contrib/lo/Dockerfile
+++ b/contrib/lo/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/lo && \
 	make

--- a/contrib/ltree/Dockerfile
+++ b/contrib/ltree/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/ltree && \
 	make

--- a/contrib/ltree_plpython/Dockerfile
+++ b/contrib/ltree_plpython/Dockerfile
@@ -19,11 +19,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure --with-python && \
 	cd contrib/ltree_plpython && \
 	make

--- a/contrib/moddatetime/Dockerfile
+++ b/contrib/moddatetime/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-    git fetch origin REL_${PG_VERSION}_STABLE && \
-    git checkout REL_${PG_VERSION}_STABLE && \
+    git fetch origin ${PG_RELEASE} && \
+    git checkout ${PG_RELEASE} && \
     ./configure && \
     cd contrib/spi && \
     make

--- a/contrib/mysql_fdw/Dockerfile
+++ b/contrib/mysql_fdw/Dockerfile
@@ -20,12 +20,12 @@ RUN apt-get update && apt-get install -y \
 RUN git clone https://github.com/postgres/postgres.git
 
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 # Build extension
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib && \
 	git clone https://github.com/EnterpriseDB/mysql_fdw.git && \

--- a/contrib/old_snapshot/Dockerfile
+++ b/contrib/old_snapshot/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/old_snapshot && \
 	make

--- a/contrib/oracle_fdw/Dockerfile
+++ b/contrib/oracle_fdw/Dockerfile
@@ -34,12 +34,12 @@ RUN mkdir /opt/oracle && \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 # Build extension
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure --without-ldap && \
 	cd contrib && \
 	git clone https://github.com/laurenz/oracle_fdw.git && \

--- a/contrib/pageinspect/Dockerfile
+++ b/contrib/pageinspect/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/pageinspect && \
 	make

--- a/contrib/passwordcheck/Dockerfile
+++ b/contrib/passwordcheck/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/passwordcheck && \
 	make

--- a/contrib/pg_bigm/Dockerfile
+++ b/contrib/pg_bigm/Dockerfile
@@ -19,13 +19,13 @@ RUN apt-get update && apt-get install -y \
 RUN git clone https://github.com/postgres/postgres.git
 
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 ARG RELEASE=v1.2-20200228
 
 # Build extension
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib && \
         git clone https://github.com/pgbigm/pg_bigm.git && \

--- a/contrib/pg_buffercache/Dockerfile
+++ b/contrib/pg_buffercache/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/pg_buffercache && \
 	make

--- a/contrib/pg_embedding/Dockerfile
+++ b/contrib/pg_embedding/Dockerfile
@@ -28,4 +28,5 @@ RUN cd postgres && \
 	cd contrib && \
 	git clone https://github.com/neondatabase/pg_embedding.git && \
 	cd pg_embedding && \
+    git checkout 710f44d && \
 	make USE_PGXS=1

--- a/contrib/pg_embedding/Dockerfile
+++ b/contrib/pg_embedding/Dockerfile
@@ -18,12 +18,12 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 # Build extension
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib && \
 	git clone https://github.com/neondatabase/pg_embedding.git && \

--- a/contrib/pg_embedding/Trunk.toml
+++ b/contrib/pg_embedding/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_embedding"
-version = "0.1.0"
+version = "0.2.0"
 repository = "https://github.com/neondatabase/pg_embedding"
 license = "PostgreSQL"
 description = "The pg_embedding extension enables the use of the Hierarchical Navigable Small World (HNSW) algorithm for vector similarity search in PostgreSQL."

--- a/contrib/pg_freespacemap/Dockerfile
+++ b/contrib/pg_freespacemap/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/pg_freespacemap && \
 	make

--- a/contrib/pg_prewarm/Dockerfile
+++ b/contrib/pg_prewarm/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/pg_prewarm && \
 	make

--- a/contrib/pg_proctab/Dockerfile
+++ b/contrib/pg_proctab/Dockerfile
@@ -18,12 +18,12 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 # Build extension
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib && \
 	git clone https://gitlab.com/pg_proctab/pg_proctab.git && \

--- a/contrib/pg_repack/Dockerfile
+++ b/contrib/pg_repack/Dockerfile
@@ -20,12 +20,12 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 # Build extension
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib && \
 	git clone https://github.com/reorg/pg_repack.git && \

--- a/contrib/pg_stat_statements/Dockerfile
+++ b/contrib/pg_stat_statements/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/pg_stat_statements && \
 	make

--- a/contrib/pg_surgery/Dockerfile
+++ b/contrib/pg_surgery/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/pg_surgery && \
 	make

--- a/contrib/pg_trgm/Dockerfile
+++ b/contrib/pg_trgm/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/pg_trgm && \
 	make

--- a/contrib/pg_visibility/Dockerfile
+++ b/contrib/pg_visibility/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/pg_visibility && \
 	make

--- a/contrib/pg_walinspect/Dockerfile
+++ b/contrib/pg_walinspect/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/pg_walinspect && \
 	make

--- a/contrib/pgaudit/Dockerfile
+++ b/contrib/pgaudit/Dockerfile
@@ -19,11 +19,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib && \
 	git clone https://github.com/pgaudit/pgaudit.git && \

--- a/contrib/pgcrypto/Dockerfile
+++ b/contrib/pgcrypto/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/pgcrypto && \
 	make

--- a/contrib/pgrowlocks/Dockerfile
+++ b/contrib/pgrowlocks/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/pgrowlocks && \
 	make

--- a/contrib/pgstattuple/Dockerfile
+++ b/contrib/pgstattuple/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/pgstattuple && \
 	make

--- a/contrib/plperl/Dockerfile
+++ b/contrib/plperl/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git 
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-    git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+    git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure --with-perl && \
 	cd src/pl/plperl && \
 	make

--- a/contrib/plperlu/Dockerfile
+++ b/contrib/plperlu/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git 
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-    git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+    git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure --with-perl && \
 	cd src/pl/plperl && \
 	make

--- a/contrib/plpgsql/Dockerfile
+++ b/contrib/plpgsql/Dockerfile
@@ -19,11 +19,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git 
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-    git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+    git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd src/pl/plpgsql && \
 	make

--- a/contrib/plprofiler/Dockerfile
+++ b/contrib/plprofiler/Dockerfile
@@ -18,12 +18,12 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 # Build extension
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib && \
 	git clone https://github.com/bigsql/plprofiler.git && \

--- a/contrib/pltcl/Dockerfile
+++ b/contrib/pltcl/Dockerfile
@@ -20,11 +20,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git 
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-    git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+    git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure --with-tcl && \
 	cd src/pl/tcl && \
 	make

--- a/contrib/pltclu/Dockerfile
+++ b/contrib/pltclu/Dockerfile
@@ -20,11 +20,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git 
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-    git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+    git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure --with-tcl && \
 	cd src/pl/tcl && \
 	make

--- a/contrib/postgres_fdw/Dockerfile
+++ b/contrib/postgres_fdw/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/postgres_fdw && \
 	make

--- a/contrib/refint/Dockerfile
+++ b/contrib/refint/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-    git fetch origin REL_${PG_VERSION}_STABLE && \
-    git checkout REL_${PG_VERSION}_STABLE && \
+    git fetch origin ${PG_RELEASE} && \
+    git checkout ${PG_RELEASE} && \
     ./configure && \
     cd contrib/spi && \
     make

--- a/contrib/rum/Dockerfile
+++ b/contrib/rum/Dockerfile
@@ -20,12 +20,12 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 # Build extension
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure --with-python && \
 	cd contrib && \
 	git clone https://github.com/postgrespro/rum.git && \

--- a/contrib/seg/Dockerfile
+++ b/contrib/seg/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/seg && \
 	make

--- a/contrib/sepgsql/Dockerfile
+++ b/contrib/sepgsql/Dockerfile
@@ -19,11 +19,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/sepgsql && \
 	make

--- a/contrib/sslinfo/Dockerfile
+++ b/contrib/sslinfo/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure --with-openssl && \
 	cd contrib/sslinfo && \
 	make

--- a/contrib/tablefunc/Dockerfile
+++ b/contrib/tablefunc/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/tablefunc && \
 	make

--- a/contrib/tcn/Dockerfile
+++ b/contrib/tcn/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/tcn && \
 	make

--- a/contrib/tds_fdw/Dockerfile
+++ b/contrib/tds_fdw/Dockerfile
@@ -22,13 +22,13 @@ RUN apt-get update && apt-get install -y \
 RUN git clone https://github.com/postgres/postgres.git
 
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 ARG RELEASE=v2.0.3
 
 # Build extension
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib && \
 	git clone https://github.com/tds-fdw/tds_fdw.git && \

--- a/contrib/test_decoding/Dockerfile
+++ b/contrib/test_decoding/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/test_decoding && \
 	make

--- a/contrib/tsm_system_rows/Dockerfile
+++ b/contrib/tsm_system_rows/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/tsm_system_rows && \
 	make

--- a/contrib/tsm_system_time/Dockerfile
+++ b/contrib/tsm_system_time/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/tsm_system_time && \
 	make

--- a/contrib/unaccent/Dockerfile
+++ b/contrib/unaccent/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure && \
 	cd contrib/unaccent && \
 	make

--- a/contrib/uuid_ossp/Dockerfile
+++ b/contrib/uuid_ossp/Dockerfile
@@ -19,11 +19,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure --with-uuid=e2fs && \
 	cd contrib/uuid-ossp && \
 	make

--- a/contrib/xml2/Dockerfile
+++ b/contrib/xml2/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y \
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git
 
-ARG PG_VERSION=15
+ARG PG_RELEASE=REL_15_3
 
 RUN cd postgres && \
-	git fetch origin REL_${PG_VERSION}_STABLE && \
-	git checkout REL_${PG_VERSION}_STABLE && \
+	git fetch origin ${PG_RELEASE} && \
+	git checkout ${PG_RELEASE} && \
 	./configure --with-libxml && \
 	cd contrib/xml2 && \
 	make


### PR DESCRIPTION
Update all extension Dockerfiles that require postgres to be built, such that the postgres version is no longer REL_15_STABLE, which is a branch, but rather REL_15_3, which is a release tag