### PR TITLE
cli: implement the `search` subcommand

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod install;
 pub mod license;
 mod pgrx;
 pub mod publish;
+pub mod search;
 pub mod test;
 
 #[async_trait]

--- a/cli/src/commands/search.rs
+++ b/cli/src/commands/search.rs
@@ -1,0 +1,36 @@
+use clap::{Args, Subcommand};
+use tokio_task_manager::Task;
+
+use super::SubCommand;
+
+#[derive(Args)]
+pub struct SearchCommand {
+    #[command(subcommand)]
+    inner: SearchSubcommand,
+}
+
+#[derive(Subcommand)]
+pub enum SearchSubcommand {
+    Extension(FindExtension),
+    Contains(DescriptionContains),
+}
+
+/// Look for extensions whose name contains the given term
+#[derive(Args)]
+pub struct FindExtension {
+    term: String,
+}
+
+/// Look for extensions whose descriptions contains the given terms
+#[derive(Args)]
+pub struct DescriptionContains {
+    terms: Vec<String>,
+}
+
+#[async_trait::async_trait]
+impl SubCommand for SearchCommand {
+    async fn execute(&self, _: Task) -> Result<(), anyhow::Error> {
+        // Stub
+        Ok(())
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -28,6 +28,8 @@ enum SubCommands {
     Install(commands::install::InstallCommand),
     /// Test a Postgres extension (coming soon)
     Test(commands::test::TestCommand),
+    /// Search for an extension
+    Search(commands::search::SearchCommand),
 }
 
 #[async_trait]
@@ -38,6 +40,7 @@ impl SubCommand for SubCommands {
             SubCommands::Publish(cmd) => cmd.execute(task).await,
             SubCommands::Install(cmd) => cmd.execute(task).await,
             SubCommands::Test(cmd) => cmd.execute(task).await,
+            SubCommands::Search(cmd) => cmd.execute(task).await,
         }
     }
 }


### PR DESCRIPTION
(WIP)

Suggested behavior:

```bash
$ trunk search --help
Search for an extension

Usage: trunk search <COMMAND>

Commands:
  extension  Look for extensions whose name contains the given term
  contains   Look for extensions whose descriptions contains the given terms
  help       Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
```

Examples:

```
$ trunk search extension ml
> postgresml
 * description
 * version
> xml2
 * description
 * version
```

```
$ trunk search contains "vector"

(Shows `pgvector` and `pg_embedding` for containing "vector" in their README/description)
```