### PR TITLE
Use `create extension if not exists` in trunk install test

### DIFF
--- a/.github/workflows/trunk-install-test.yml
+++ b/.github/workflows/trunk-install-test.yml
@@ -17,7 +17,7 @@ jobs:
       - self-hosted
       - dind
       - large-8x8
-    container: quay.io/tembo/trunk-test:0.0.10
+    container: quay.io/tembo/trunk-test:0.0.11
     env:
       PGHOST: "localhost"
       PGPORT: "5432"

--- a/.github/workflows/trunk-install-test.yml
+++ b/.github/workflows/trunk-install-test.yml
@@ -17,7 +17,7 @@ jobs:
       - self-hosted
       - dind
       - large-8x8
-    container: quay.io/tembo/trunk-test:2678193
+    container: quay.io/tembo/trunk-test:0.0.10
     env:
       PGHOST: "localhost"
       PGPORT: "5432"

--- a/.github/workflows/trunk-install-test.yml
+++ b/.github/workflows/trunk-install-test.yml
@@ -17,7 +17,7 @@ jobs:
       - self-hosted
       - dind
       - large-8x8
-    container: quay.io/tembo/trunk-test:0.0.11
+    container: quay.io/tembo/trunk-test:0.0.12
     env:
       PGHOST: "localhost"
       PGPORT: "5432"

--- a/images/trunk-test/Dockerfile
+++ b/images/trunk-test/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y \
     libreadline-dev \
     zlib1g-dev \
     libpq-dev \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
 STOPSIGNAL SIGINT
@@ -42,6 +43,11 @@ RUN set -eux; \
 ENV LANG en_US.utf8
 
 RUN mkdir /docker-entrypoint-initdb.d
+
+RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    apt-get update && \
+    apt-get upgrade -y
 
 # Install postgres and some extensions
 RUN apt-get update && apt-get install -y \

--- a/images/trunk-test/trunk-install.sh
+++ b/images/trunk-test/trunk-install.sh
@@ -6,7 +6,7 @@ lines=$(cat $file)
 for line in $lines
 do
         trunk install $line
-        psql -c "create extension \"$line\" cascade;" | grep -i error | grep -v 'already exists' &> /dev/null
+        psql -c "create extension if not exists \"$line\" cascade;"
         if [ $? -ne 0 ]; then
             echo "CREATE EXTENSION command failed"
             failed_extensions+=("$line")

--- a/images/trunk-test/trunk-install.sh
+++ b/images/trunk-test/trunk-install.sh
@@ -6,7 +6,7 @@ lines=$(cat $file)
 for line in $lines
 do
         trunk install $line
-        psql -c "create extension \"$line\" cascade;"
+        psql -c "create extension \"$line\" cascade;" | grep -i error | grep -v 'already exists' &> /dev/null
         if [ $? -ne 0 ]; then
             echo "CREATE EXTENSION command failed"
             failed_extensions+=("$line")


### PR DESCRIPTION
- Update `libpq5` and `libpq-dev` to `15.3-1`
- Use `create extension if not exists` to reduce failure