### PR TITLE
Remove discord shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 [![version](https://img.shields.io/crates/v/pg-trunk?label=CLI&logo=rust)](https://crates.io/crates/pg-trunk)
 [![OSSRank](https://shields.io/endpoint?url=https://ossrank.com/shield/2643)](https://ossrank.com/p/2643)
-[![Discord Chat](https://img.shields.io/discord/1060568981725003789?label=Discord)][Discord]
 
 Trunk is an open source package manager and registry for Postgres extensions. Use the Trunk CLI to build, publish
 and install Postgres extensions _of all kinds_.


### PR DESCRIPTION
Remove discord shield from README. The discord server has been deleted.