### PR TITLE
Add libpython3.10-dev dependency to trunk install test image

### DIFF
--- a/.github/workflows/trunk-install-test.yml
+++ b/.github/workflows/trunk-install-test.yml
@@ -17,7 +17,7 @@ jobs:
       - self-hosted
       - dind
       - large-8x8
-    container: quay.io/tembo/trunk-test:0.0.17
+    container: quay.io/tembo/trunk-test:0.0.18
     env:
       PGHOST: "localhost"
       PGPORT: "5432"

--- a/images/trunk-test/Dockerfile
+++ b/images/trunk-test/Dockerfile
@@ -62,6 +62,7 @@ RUN apt-get update && apt-get install -y \
     libboost-serialization1.74-dev \
     libhiredis-dev \
     libsybdb5 \
+    libpython3.10-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Build Postgres from source


### PR DESCRIPTION
Resolves 4 extension installation failures.