### PR TITLE
contrib: add the `pgroonga` extension

### DIFF
--- a/contrib/pgroonga/Dockerfile
+++ b/contrib/pgroonga/Dockerfile
@@ -1,0 +1,31 @@
+# Set PostgreSQL version
+ARG PG_VERSION=15
+FROM quay.io/coredb/c-builder:pg${PG_VERSION}
+USER root
+
+# Extension build dependencies
+RUN apt-get update && apt-get install -y \
+    wget tar build-essential zlib1g-dev liblzo2-dev libxxhash-dev \
+    libmsgpack-dev libzmq3-dev libevent-dev libmecab-dev
+
+# Build Groonga 13.0.4
+RUN wget https://packages.groonga.org/source/groonga/groonga-13.0.4.tar.gz \
+    && tar xvzf groonga-13.0.4.tar.gz \
+    && cd groonga-13.0.4 \
+    && ./configure \
+    && make -j$(grep '^processor' /proc/cpuinfo | wc -l) \
+    && make install
+
+# Download and decompress the release's archive
+RUN curl -L -o pgroonga.tar.gz https://github.com/pgroonga/pgroonga/archive/refs/tags/3.1.1.tar.gz \
+    && mkdir pgroonga \
+    && tar -xzvf pgroonga.tar.gz -C pgroonga --strip-components=1 \
+    && cd pgroonga/vendor/ \
+    && git clone https://github.com/Cyan4973/xxHash
+
+# Set project version
+ARG RELEASE=3.1.1
+
+# Build extension
+RUN cd pgroonga \
+    && make

--- a/contrib/pgroonga/Trunk.toml
+++ b/contrib/pgroonga/Trunk.toml
@@ -1,0 +1,19 @@
+[extension]
+name = "pgroonga"
+version = "3.1.1"
+repository = "https://github.com/pgroonga/pgroonga"
+license = "PostgreSQL"
+description = "PGroonga makes PostgreSQL fast full text search platform for all languages."
+documentation = "https://pgroonga.github.io/"
+categories = ["search"]
+
+[build]
+postgres_version = "15"
+platform = "linux/amd64"
+dockerfile = "Dockerfile"
+install_command = """
+    cd pgroonga && make install
+    set -x
+    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
+    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
+    """


### PR DESCRIPTION
Adds the `pgroonga` extension

Notes for @ianstanton & @EvanHStanton:

* We need `libroonga` >= 13. in order to build `pgroonga` 3.1, but the Docker image's repository has it at version 12.
   Due to this, the Dockerfile is building `Roonga` from source, which is kind of slow. This can be removed if we get to update the Docker image's Ubuntu release, if possible
* `pgroonga` doesn't have separate branches for each release so I set it to download the source code via the GitHub-supplied `.tar.gz` archive, if that's OK
  