### PR TITLE
Fix `semver` ordering

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -60,7 +60,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev
       - name: install sqlx-cli
-        run: cargo install sqlx-cli --version 0.6.2
+        run: cargo install sqlx-cli@0.6.2
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "lint"

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -60,7 +60,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev
       - name: install sqlx-cli
-        run: cargo install sqlx-cli
+        run: cargo install sqlx-cli --version 0.6.1
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "lint"

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -60,7 +60,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev
       - name: install sqlx-cli
-        run: cargo install sqlx-cli --version 0.6.1
+        run: cargo install sqlx-cli --version 0.6.2
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "lint"

--- a/registry/sqlx-data.json
+++ b/registry/sqlx-data.json
@@ -80,6 +80,26 @@
     },
     "query": "SELECT user_id\n                FROM api_tokens\n                WHERE\n                    token = $1"
   },
+  "152d01b0e157fa58129e96f5bd3e7536e393feb12f12adcafadbabebd0918fa9": {
+    "describe": {
+      "columns": [
+        {
+          "name": "num",
+          "ordinal": 0,
+          "type_info": "Varchar"
+        }
+      ],
+      "nullable": [
+        true
+      ],
+      "parameters": {
+        "Left": [
+          "Int4"
+        ]
+      }
+    },
+    "query": "SELECT num FROM versions WHERE extension_id = $1 ORDER BY string_to_array(num, '.')::int[] DESC LIMIT 1;"
+  },
   "1d305b40cb84e8ed2a3f1ed57a9bc8375387a13936128bf91ae5f30e0ee75d5e": {
     "describe": {
       "columns": [],
@@ -547,26 +567,6 @@
       }
     },
     "query": "\n            INSERT INTO extensions(name, created_at, updated_at, description, homepage, documentation, repository)\n            VALUES ($1, (now() at time zone 'utc'), (now() at time zone 'utc'), $2, $3, $4, $5)\n            RETURNING id\n            "
-  },
-  "514adcd37018e70d0c1e0ca4c7726d6d4e733d8d3c4c893290bf87eca4452abf": {
-    "describe": {
-      "columns": [
-        {
-          "name": "max",
-          "ordinal": 0,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        null
-      ],
-      "parameters": {
-        "Left": [
-          "Int4"
-        ]
-      }
-    },
-    "query": "SELECT MAX(num) FROM versions WHERE extension_id = $1;"
   },
   "5650cfabaad409805e475fa8677e93ee489ee6e2f95d811635ec6b6ffbcce688": {
     "describe": {

--- a/registry/src/download.rs
+++ b/registry/src/download.rs
@@ -13,12 +13,8 @@ pub async fn latest_version(
         .fetch_one(&mut tx)
         .await?;
     let id: i32 = ext.id as i32;
-    // trigger
-    let latest = sqlx::query!(
-        "SELECT num FROM versions WHERE extension_id = $1 ORDER BY created_at DESC LIMIT 1;",
-        id
-    )
-    .fetch_one(&mut tx)
-    .await?;
+    let latest = sqlx::query!("SELECT num FROM versions WHERE extension_id = $1 ORDER BY string_to_array(num, '.')::int[] DESC LIMIT 1;", id)
+        .fetch_one(&mut tx)
+        .await?;
     Ok(latest.num.unwrap())
 }

--- a/registry/src/download.rs
+++ b/registry/src/download.rs
@@ -13,7 +13,7 @@ pub async fn latest_version(
         .fetch_one(&mut tx)
         .await?;
     let id: i32 = ext.id as i32;
-    let latest = sqlx::query!("SELECT * FROM versions WHERE extension_id = $1 ORDER BY string_to_array(num, '.')::int[] DESC LIMIT 1;", id)
+    let latest = sqlx::query!("SELECT num FROM versions WHERE extension_id = $1 ORDER BY string_to_array(num, '.')::int[] DESC LIMIT 1;", id)
         .fetch_one(&mut tx)
         .await?;
     Ok(latest.num.unwrap())

--- a/registry/src/download.rs
+++ b/registry/src/download.rs
@@ -13,7 +13,7 @@ pub async fn latest_version(
         .fetch_one(&mut tx)
         .await?;
     let id: i32 = ext.id as i32;
-    let latest = sqlx::query!("SELECT num FROM versions WHERE extension_id = $1 ORDER BY string_to_array(num, '.')::int[] DESC LIMIT 1;", id)
+    let latest = sqlx::query!("SELECT * FROM versions WHERE extension_id = $1 ORDER BY string_to_array(num, '.')::int[] DESC LIMIT 1;", id)
         .fetch_one(&mut tx)
         .await?;
     Ok(latest.num.unwrap())

--- a/registry/src/download.rs
+++ b/registry/src/download.rs
@@ -17,7 +17,7 @@ pub async fn latest_version(
         "SELECT num FROM versions WHERE extension_id = $1 ORDER BY created_at DESC LIMIT 1;",
         id
     )
-    .fetch_one(&mut tx)
+    .fetch_optional(&mut tx)
     .await?;
-    Ok(latest.num.unwrap())
+    Ok(latest.unwrap().num.unwrap())
 }

--- a/registry/src/download.rs
+++ b/registry/src/download.rs
@@ -13,8 +13,11 @@ pub async fn latest_version(
         .fetch_one(&mut tx)
         .await?;
     let id: i32 = ext.id as i32;
-    let latest = sqlx::query!("SELECT num FROM versions WHERE extension_id = $1 ORDER BY created_at DESC LIMIT 1;", id)
-        .fetch_one(&mut tx)
-        .await?;
+    let latest = sqlx::query!(
+        "SELECT num FROM versions WHERE extension_id = $1 ORDER BY created_at DESC LIMIT 1;",
+        id
+    )
+    .fetch_one(&mut tx)
+    .await?;
     Ok(latest.num.unwrap())
 }

--- a/registry/src/download.rs
+++ b/registry/src/download.rs
@@ -13,8 +13,8 @@ pub async fn latest_version(
         .fetch_one(&mut tx)
         .await?;
     let id: i32 = ext.id as i32;
-    let latest = sqlx::query!("SELECT MAX(num) FROM versions WHERE extension_id = $1;", id)
+    let latest = sqlx::query!("SELECT num FROM versions WHERE extension_id = $1 ORDER BY created_at DESC LIMIT 1;", id)
         .fetch_one(&mut tx)
         .await?;
-    Ok(latest.max.unwrap())
+    Ok(latest.num.unwrap())
 }

--- a/registry/src/download.rs
+++ b/registry/src/download.rs
@@ -14,8 +14,11 @@ pub async fn latest_version(
         .await?;
     let id: i32 = ext.id as i32;
     // trigger
-    let latest = sqlx::query!("SELECT MAX(num) FROM versions WHERE extension_id = $1;", id)
-        .fetch_one(&mut tx)
-        .await?;
-    Ok(latest.max.unwrap())
+    let latest = sqlx::query!(
+        "SELECT num FROM versions WHERE extension_id = $1 ORDER BY created_at DESC LIMIT 1;",
+        id
+    )
+    .fetch_one(&mut tx)
+    .await?;
+    Ok(latest.num.unwrap())
 }

--- a/registry/src/download.rs
+++ b/registry/src/download.rs
@@ -17,7 +17,7 @@ pub async fn latest_version(
         "SELECT num FROM versions WHERE extension_id = $1 ORDER BY created_at DESC LIMIT 1;",
         id
     )
-    .fetch_optional(&mut tx)
+    .fetch_one(&mut tx)
     .await?;
-    Ok(latest.unwrap().num.unwrap())
+    Ok(latest.num.unwrap())
 }

--- a/registry/src/download.rs
+++ b/registry/src/download.rs
@@ -13,11 +13,9 @@ pub async fn latest_version(
         .fetch_one(&mut tx)
         .await?;
     let id: i32 = ext.id as i32;
-    let latest = sqlx::query!(
-        "SELECT num FROM versions WHERE extension_id = $1 ORDER BY created_at DESC LIMIT 1;",
-        id
-    )
-    .fetch_one(&mut tx)
-    .await?;
-    Ok(latest.num.unwrap())
+    // trigger
+    let latest = sqlx::query!("SELECT MAX(num) FROM versions WHERE extension_id = $1;", id)
+        .fetch_one(&mut tx)
+        .await?;
+    Ok(latest.max.unwrap())
 }


### PR DESCRIPTION
Fix improper ordering of versions. Fetch latest version by `created_at`.