### PR TITLE
Only run CLI CI when relevant changes are made

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -13,10 +13,13 @@ on:
       - '.github/workflows/cli.yml'
       - 'cli/**'
       - '!cli/README.md'
-  # Always run tests on main or release branches
   push:
     branches:
       - main
+    paths:
+      - '.github/workflows/cli.yml'
+      - 'cli/**'
+      - '!cli/README.md'
 
 jobs:
   lint:


### PR DESCRIPTION
CLI CI runs on every commit to `main` branch. With this change, we'll only run the CLI CI for relevant commits.