### PR TITLE
CI: CREATE EXTENSION based on `pg_available_extensions`

### DIFF
--- a/.github/workflows/trunk-install-test.yml
+++ b/.github/workflows/trunk-install-test.yml
@@ -17,7 +17,7 @@ jobs:
       - self-hosted
       - dind
       - large-8x8
-    container: quay.io/tembo/trunk-test:0.0.21
+    container: quay.io/tembo/trunk-test:0.0.22
     env:
       PGHOST: "localhost"
       PGPORT: "5432"

--- a/.github/workflows/trunk-install-test.yml
+++ b/.github/workflows/trunk-install-test.yml
@@ -17,7 +17,7 @@ jobs:
       - self-hosted
       - dind
       - large-8x8
-    container: quay.io/tembo/trunk-test:0.0.22
+    container: quay.io/tembo/trunk-test:0.0.23
     env:
       PGHOST: "localhost"
       PGPORT: "5432"

--- a/.github/workflows/trunk-install-test.yml
+++ b/.github/workflows/trunk-install-test.yml
@@ -17,7 +17,7 @@ jobs:
       - self-hosted
       - dind
       - large-8x8
-    container: quay.io/tembo/trunk-test:0.0.23
+    container: quay.io/tembo/trunk-test:0.0.24
     env:
       PGHOST: "localhost"
       PGPORT: "5432"

--- a/images/trunk-test/trunk-install.sh
+++ b/images/trunk-test/trunk-install.sh
@@ -7,7 +7,7 @@ for line in $lines
 do
         trunk install $line
         if [ $? -ne 0 ]; then
-            echo "CREATE EXTENSION command failed"
+            echo "trunk install command failed"
             failed_extensions+=("$line")
         fi
         printf "\n\n"

--- a/images/trunk-test/trunk-install.sh
+++ b/images/trunk-test/trunk-install.sh
@@ -9,7 +9,7 @@ do
         printf "\n\n"
 done
 IFS=$'\n' extensions=(`psql -tA postgres -c 'select name from pg_available_extensions;'`)
-for ext in $extensions
+for ext in "${extensions[@]}"
 do
         psql -c "create extension if not exists \"$ext\" cascade;"
         if [ $? -ne 0 ]; then

--- a/images/trunk-test/trunk-install.sh
+++ b/images/trunk-test/trunk-install.sh
@@ -6,7 +6,12 @@ lines=$(cat $file)
 for line in $lines
 do
         trunk install $line
-        psql -c "create extension if not exists \"$line\" cascade;"
+        printf "\n\n"
+done
+IFS=$'\n' extensions=(`psql -tA postgres -c 'select name from pg_available_extensions;'`)
+for ext in $extensions
+do
+        psql -c "create extension if not exists \"$ext\" cascade;"
         if [ $? -ne 0 ]; then
             echo "CREATE EXTENSION command failed"
             failed_extensions+=("$line")

--- a/images/trunk-test/trunk-install.sh
+++ b/images/trunk-test/trunk-install.sh
@@ -6,6 +6,10 @@ lines=$(cat $file)
 for line in $lines
 do
         trunk install $line
+        if [ $? -ne 0 ]; then
+            echo "CREATE EXTENSION command failed"
+            failed_extensions+=("$line")
+        fi
         printf "\n\n"
 done
 IFS=$'\n' extensions=(`psql -tA postgres -c 'select name from pg_available_extensions;'`)
@@ -14,7 +18,7 @@ do
         psql -c "create extension if not exists \"$ext\" cascade;"
         if [ $? -ne 0 ]; then
             echo "CREATE EXTENSION command failed"
-            failed_extensions+=("$line")
+            failed_extensions+=("$ext")
         fi
         printf "\n\n"
 done


### PR DESCRIPTION
Run `CREATE EXTENSION` based on `pg_available_extensions` in our `trunk install` test for all extensions at pgt.dev. This resolves name mismatch failures and decreases failure rate by 13%.