### PR TITLE
Update to recent Apache2.0 commit

### DIFF
--- a/contrib/pg_embedding/Dockerfile
+++ b/contrib/pg_embedding/Dockerfile
@@ -28,5 +28,5 @@ RUN cd postgres && \
 	cd contrib && \
 	git clone https://github.com/neondatabase/pg_embedding.git && \
 	cd pg_embedding && \
-    git checkout 710f44d && \
+    git checkout 2e0fe9c && \
 	make USE_PGXS=1

--- a/contrib/pg_embedding/Trunk.toml
+++ b/contrib/pg_embedding/Trunk.toml
@@ -1,8 +1,8 @@
 [extension]
 name = "pg_embedding"
-version = "0.2.0"
+version = "0.3.5"
 repository = "https://github.com/neondatabase/pg_embedding"
-license = "PostgreSQL"
+license = "Apache-2.0"
 description = "The pg_embedding extension enables the use of the Hierarchical Navigable Small World (HNSW) algorithm for vector similarity search in PostgreSQL."
 homepage = "https://neon.tech/"
 documentation = "https://github.com/neondatabase/pg_embedding"


### PR DESCRIPTION
- Update ```pg_embedding``` Dockerfile to most recent commit [2e0fe9c], as most recent release did not include Apache-2.0 license update
- Update ```pg_embedding``` Trunk.toml version to 0.3.5
- Update ```pg_embedding``` Trunk.toml license to Apache-2.0