### PR TITLE
CI: Enable extension based on `pg_available_extensions` for extension PRs

### DIFF
--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -101,7 +101,7 @@ jobs:
         run: |
           docker-entrypoint.sh postgres &
           sleep 5
-          export EXTENSION=$(psql -U postgres -c "select name from pg_available_extensions where name NOT IN ('plpgsql')";)
+          export EXTENSION=$(psql -U postgres -tA -c "select name from pg_available_extensions where name NOT IN ('plpgsql')";)
           psql -U postgres -c "create extension if not exists \"$EXTENSION\" cascade;"
       - name: Publish the extension
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -101,7 +101,8 @@ jobs:
         run: |
           docker-entrypoint.sh postgres &
           sleep 5
-          EXTENSION=$(basename ${{ matrix.path }}) && psql -U postgres -c "create extension if not exists \"$EXTENSION\" cascade;"
+          EXTENSION=$(psql -U postgres -c "select name from pg_available_extensions where name NOT IN ('plpgsql');
+          psql -U postgres -c "create extension if not exists \"$EXTENSION\" cascade;"
       - name: Publish the extension
         if: ${{ github.ref == 'refs/heads/main' }}
         run: cd ${{ matrix.path }} && trunk publish

--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -101,7 +101,7 @@ jobs:
         run: |
           docker-entrypoint.sh postgres &
           sleep 5
-          EXTENSION=$(psql -U postgres -c "select name from pg_available_extensions where name NOT IN ('plpgsql');
+          EXTENSION=$(psql -U postgres -c "select name from pg_available_extensions where name NOT IN ('plpgsql'););
           psql -U postgres -c "create extension if not exists \"$EXTENSION\" cascade;"
       - name: Publish the extension
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -101,7 +101,7 @@ jobs:
         run: |
           docker-entrypoint.sh postgres &
           sleep 5
-          EXTENSION=$(psql -U postgres -c "select name from pg_available_extensions where name NOT IN ('plpgsql'););
+          export EXTENSION=$(psql -U postgres -c "select name from pg_available_extensions where name NOT IN ('plpgsql')";)
           psql -U postgres -c "create extension if not exists \"$EXTENSION\" cascade;"
       - name: Publish the extension
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/contrib/pgsql_http/Trunk.toml
+++ b/contrib/pgsql_http/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pgsql_http"
-version = "1.5.1"
+version = "1.5.0"
 repository = "https://github.com/pramsey/pgsql-http"
 license = "MIT"
 description = "HTTP client for PostgreSQL, retrieve a web page from inside the database."

--- a/contrib/pgsql_http/Trunk.toml
+++ b/contrib/pgsql_http/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pgsql_http"
-version = "1.5.0"
+version = "1.5.1"
 repository = "https://github.com/pramsey/pgsql-http"
 license = "MIT"
 description = "HTTP client for PostgreSQL, retrieve a web page from inside the database."


### PR DESCRIPTION
Run `CREATE EXTENSION` from `pg_available_extensions` in extension PR CI. This will help resolved errors by enabling the extension with its proper name.