### PR TITLE
Bump image to include trunk CLI 0.10.4

### DIFF
--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -57,7 +57,7 @@ jobs:
       - dind
       - large-8x8
     container:
-      image: quay.io/tembo/trunk-test-tembo:0.0.5
+      image: quay.io/tembo/trunk-test-tembo:0.0.22
       options: --user root
     needs:
       - find_directories

--- a/.github/workflows/trunk-install-test.yml
+++ b/.github/workflows/trunk-install-test.yml
@@ -18,7 +18,7 @@ jobs:
       - dind
       - large-8x8
     container:
-      image: quay.io/tembo/trunk-test-tembo:0.0.21
+      image: quay.io/tembo/trunk-test-tembo:0.0.22
       options: --user root
     env:
       PGHOST: "localhost"

--- a/images/trunk-test-tembo/Dockerfile
+++ b/images/trunk-test-tembo/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/tembo/tembo-pg-cnpg:15.3.0-5-429c3cd
+FROM quay.io/tembo/tembo-pg-cnpg:57ff3aa
 
 USER root
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Build test image with base image including trunk CLI `0.10.4` (https://github.com/tembo-io/tembo-images/pull/21)