### PR TITLE
cli: Add `shared_preload_libraries` to publish and install metadata

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.10.5"
+version = "0.11.5"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton", "Vinícius Miguel"]
 description = "A package manager for PostgreSQL extensions"

--- a/cli/src/commands/install.rs
+++ b/cli/src/commands/install.rs
@@ -415,12 +415,11 @@ fn print_post_installation_guide(manifest: &Manifest) {
         }
     }
     // If the manifest has shared_preload_libraries, then we need to add the extension to shared_preload_libraries
+    // shared_preload_libraries = 'spl1,spl2'
     if let Some(shared_preload_libraries) = &manifest.shared_preload_libraries {
+        let spl = shared_preload_libraries.join(",");
         println!("\nAdd the following to your postgresql.conf:");
-        println!(
-            "\tshared_preload_libraries = '{:?}'",
-            shared_preload_libraries
-        );
+        println!("\tshared_preload_libraries = '{}'", spl);
     }
 
     println!("\nEnable the extension with:");

--- a/cli/src/commands/install.rs
+++ b/cli/src/commands/install.rs
@@ -415,7 +415,7 @@ fn print_post_installation_guide(manifest: &Manifest) {
         }
     }
     // If the manifest has shared_preload_libraries, then we need to add the extension to shared_preload_libraries
-    // shared_preload_libraries = 'spl1,spl2'
+    // Output will look like shared_preload_libraries = 'spl1,spl2,spl3'
     if let Some(shared_preload_libraries) = &manifest.shared_preload_libraries {
         let spl = shared_preload_libraries.join(",");
         println!("\nAdd the following to your postgresql.conf:");

--- a/cli/src/commands/install.rs
+++ b/cli/src/commands/install.rs
@@ -406,11 +406,11 @@ fn print_post_installation_guide(manifest: &Manifest) {
     println!("***************************");
 
     if let Some(dependency_declaration) = &manifest.dependencies {
-        println!("\n\tNeeded system-level dependencies:");
+        println!("\nInstall the following system-level dependencies:");
         for (package_manager, dependencies) in dependency_declaration {
-            println!("\n\t* On systems using {package_manager}:");
+            println!("\tOn systems using {package_manager}:");
             for dependency in dependencies {
-                println!("\t\t{dependency}\n");
+                println!("\t\t{dependency}");
             }
         }
     }
@@ -424,5 +424,5 @@ fn print_post_installation_guide(manifest: &Manifest) {
     }
 
     println!("\nEnable the extension with:");
-    println!("CREATE EXTENSION IF NOT EXISTS {extension_name} CASCADE;");
+    println!("\tCREATE EXTENSION IF NOT EXISTS {extension_name} CASCADE;");
 }

--- a/cli/src/commands/install.rs
+++ b/cli/src/commands/install.rs
@@ -414,6 +414,11 @@ fn print_post_installation_guide(manifest: &Manifest) {
             }
         }
     }
+    // If the manifest has shared_preload_libraries, then we need to add the extension to shared_preload_libraries
+    if let Some(shared_preload_libraries) = &manifest.shared_preload_libraries {
+        println!("\nAdd the following to your postgresql.conf:");
+        println!("\tshared_preload_libraries = '{:?}'", shared_preload_libraries);
+    }
 
     println!("\nEnable the extension with:");
     println!("CREATE EXTENSION IF NOT EXISTS {extension_name} CASCADE;");

--- a/cli/src/commands/install.rs
+++ b/cli/src/commands/install.rs
@@ -417,7 +417,10 @@ fn print_post_installation_guide(manifest: &Manifest) {
     // If the manifest has shared_preload_libraries, then we need to add the extension to shared_preload_libraries
     if let Some(shared_preload_libraries) = &manifest.shared_preload_libraries {
         println!("\nAdd the following to your postgresql.conf:");
-        println!("\tshared_preload_libraries = '{:?}'", shared_preload_libraries);
+        println!(
+            "\tshared_preload_libraries = '{:?}'",
+            shared_preload_libraries
+        );
     }
 
     println!("\nEnable the extension with:");

--- a/cli/src/commands/publish.rs
+++ b/cli/src/commands/publish.rs
@@ -258,6 +258,7 @@ impl SubCommand for PublishCommand {
         };
 
         // TODO(ianstanton) DRY this up
+        // TODO(ianstanton) Read system dependencies and shared_preload_libraries from manifest.json
         // If extension_name is not provided by the user, check for value in manifest.json
         if publish_settings.extension_name.is_none() {
             println!("Fetching extension_name from manifest.json...");

--- a/cli/src/commands/publish.rs
+++ b/cli/src/commands/publish.rs
@@ -104,7 +104,7 @@ impl PublishCommand {
             &trunk_toml,
         );
 
-        let shared_preload_library = cli_or_trunk_opt(
+        let shared_preload_libraries = cli_or_trunk_opt(
             &self.shared_preload_libraries,
             |toml| &toml.extension.shared_preload_libraries,
             &trunk_toml,
@@ -185,9 +185,9 @@ impl PublishCommand {
             repository,
             name,
             extension_name,
-            shared_preload_libraries,
             system_dependencies,
             categories,
+            shared_preload_libraries,
         })
     }
 }

--- a/cli/src/commands/publish.rs
+++ b/cli/src/commands/publish.rs
@@ -25,7 +25,7 @@ pub struct PublishCommand {
     name: Option<String>,
     #[arg(short = 'e', long = "extension_name")]
     extension_name: Option<String>,
-    #[arg(short = 's', long = "shared_preload_libraries"]
+    #[arg(short = 's', long = "shared_preload_libraries")]
     shared_preload_libraries: Option<Vec<String>>,
     #[arg(long = "version", short = 'v')]
     version: Option<String>,

--- a/cli/src/commands/publish.rs
+++ b/cli/src/commands/publish.rs
@@ -347,7 +347,6 @@ impl SubCommand for PublishCommand {
         let m = json!({
             "name": publish_settings.name,
             "extension_name": publish_settings.extension_name,
-            "shared_preload_libraries": publish_settings.shared_preload_libraries,
             "vers": publish_settings.version,
             "description": publish_settings.description,
             "documentation": publish_settings.documentation,
@@ -355,7 +354,8 @@ impl SubCommand for PublishCommand {
             "license": publish_settings.license,
             "repository": publish_settings.repository,
             "system_dependencies": publish_settings.system_dependencies,
-            "categories": publish_settings.categories
+            "categories": publish_settings.categories,
+            "libraries": publish_settings.shared_preload_libraries,
         });
         let metadata = reqwest::multipart::Part::text(m.to_string()).headers(headers);
         let form = reqwest::multipart::Form::new()

--- a/cli/src/commands/publish.rs
+++ b/cli/src/commands/publish.rs
@@ -25,6 +25,8 @@ pub struct PublishCommand {
     name: Option<String>,
     #[arg(short = 'e', long = "extension_name")]
     extension_name: Option<String>,
+    #[arg(short = 's', long = "shared_preload_libraries"]
+    shared_preload_libraries: Option<Vec<String>>,
     #[arg(long = "version", short = 'v')]
     version: Option<String>,
     #[arg(long = "file", short = 'f')]
@@ -61,6 +63,7 @@ pub struct Category {
 pub struct PublishSettings {
     name: String,
     extension_name: Option<String>,
+    shared_preload_libraries: Option<Vec<String>>,
     version: String,
     file: Option<PathBuf>,
     description: Option<String>,
@@ -98,6 +101,12 @@ impl PublishCommand {
         let extension_name = cli_or_trunk_opt(
             &self.extension_name,
             |toml| &toml.extension.extension_name,
+            &trunk_toml,
+        );
+
+        let shared_preload_library = cli_or_trunk_opt(
+            &self.shared_preload_libraries,
+            |toml| &toml.extension.shared_preload_libraries,
             &trunk_toml,
         );
 
@@ -176,6 +185,7 @@ impl PublishCommand {
             repository,
             name,
             extension_name,
+            shared_preload_libraries,
             system_dependencies,
             categories,
         })
@@ -336,6 +346,7 @@ impl SubCommand for PublishCommand {
         let m = json!({
             "name": publish_settings.name,
             "extension_name": publish_settings.extension_name,
+            "shared_preload_libraries": publish_settings.shared_preload_libraries,
             "vers": publish_settings.version,
             "description": publish_settings.description,
             "documentation": publish_settings.documentation,

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -631,6 +631,20 @@ fn build_pgrx_with_trunk_toml() -> Result<(), Box<dyn std::error::Error>> {
     assert!(stdout.contains("\"another_shared_preload_library\""));
     assert!(stdout.contains("\"libpq5\""));
 
+    // Get output of 'pg_config --pkglibdir'
+    let output = Command::new("pg_config")
+        .arg("--pkglibdir")
+        .output()
+        .expect("failed to find pkglibdir, is pg_config in path?");
+    let pkglibdir = String::from_utf8(output.stdout)?;
+    let pkglibdir = pkglibdir.trim();
+
+    // Remove .so if it exists
+    let _rm_so = Command::new("rm")
+        .arg(format!("{pkglibdir}/test_pgrx_extension.so").as_str())
+        .output()
+        .expect("failed to remove .so file");
+
     // assert post installation steps contain correct CREATE EXTENSION command
     let mut cmd = Command::cargo_bin(CARGO_BIN)?;
     cmd.arg("install");

--- a/cli/tests/test_trunk_toml_dirs/pgrx_with_trunk_toml/Trunk.toml
+++ b/cli/tests/test_trunk_toml_dirs/pgrx_with_trunk_toml/Trunk.toml
@@ -1,7 +1,7 @@
 [extension]
 name = "test_pgrx_extension"
 extension_name = "extension_name_from_toml"
-shared_preload_libraries = ["shared_preload_libraries_from_toml"]
+shared_preload_libraries = ["shared_preload_libraries_from_toml", "another_shared_preload_library"]
 version = "0.0.0"
 repository = "https://github.com/tembo-io/trunk"
 license = "PostgreSQL"


### PR DESCRIPTION
### Trunk version
- Updated to match semver functionality update
### Publish
- Add option to specify shared_preload_libraries via CLI or Trunk.toml