### PR TITLE
ui: experiment disabling Next.js compression

### DIFF
--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  compress: false 
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Check performance gains/losses if Next.js compression is disabled

## Why would this be good?

As per [Next.js docs](https://nextjs.org/docs/pages/api-reference/next-config-js/compress), this should offload decompression from Node.js, enabling our main thread to be more responsive 