### PR TITLE
registry: add reworked /extensions/all endpoint (in beta)

### DIFF
--- a/registry/Cargo.lock
+++ b/registry/Cargo.lock
@@ -2885,7 +2885,6 @@ dependencies = [
  "sha2",
  "sqlx",
  "thiserror",
- "time 0.3.28",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/registry/Cargo.lock
+++ b/registry/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2",
- "time 0.3.20",
+ "time 0.3.28",
  "url",
 ]
 
@@ -357,7 +357,7 @@ dependencies = [
  "http",
  "hyper",
  "ring",
- "time 0.3.20",
+ "time 0.3.28",
  "tokio",
  "tower",
  "tracing",
@@ -527,7 +527,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "sha2",
- "time 0.3.20",
+ "time 0.3.28",
  "tracing",
 ]
 
@@ -667,7 +667,7 @@ dependencies = [
  "itoa",
  "num-integer",
  "ryu",
- "time 0.3.20",
+ "time 0.3.28",
 ]
 
 [[package]]
@@ -862,7 +862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.20",
+ "time 0.3.28",
  "version_check",
 ]
 
@@ -1030,6 +1030,15 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1262,7 +1271,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2018,18 +2027,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -2281,22 +2290,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.154"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdd151213925e7f1ab45a9bbfb129316bd00799784b174b7cc7bcd16961c49e"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.154"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2344,7 +2353,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.20",
+ "time 0.3.28",
 ]
 
 [[package]]
@@ -2408,7 +2417,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.28",
 ]
 
 [[package]]
@@ -2508,7 +2517,7 @@ dependencies = [
  "sqlx-rt",
  "stringprep",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.28",
  "tokio-stream",
  "url",
  "whoami",
@@ -2583,9 +2592,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2657,10 +2666,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
 dependencies = [
+ "deranged",
  "itoa",
  "serde",
  "time-core",
@@ -2669,15 +2679,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
 dependencies = [
  "time-core",
 ]
@@ -2874,6 +2884,7 @@ dependencies = [
  "sha2",
  "sqlx",
  "thiserror",
+ "time 0.3.28",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/registry/Cargo.lock
+++ b/registry/Cargo.lock
@@ -2484,6 +2484,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "dirs",

--- a/registry/Cargo.toml
+++ b/registry/Cargo.toml
@@ -31,3 +31,4 @@ rand = "0.8.5"
 sha2 = "0.10.6"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
+time = { version = "^0.3.2", features = ["serde"] }

--- a/registry/Cargo.toml
+++ b/registry/Cargo.toml
@@ -31,4 +31,3 @@ rand = "0.8.5"
 sha2 = "0.10.6"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
-time = { version = "^0.3.2", features = ["serde"] }

--- a/registry/Cargo.toml
+++ b/registry/Cargo.toml
@@ -13,14 +13,14 @@ base64 = "0.21.0"
 actix-cors = "0.6.4"
 actix-multipart = "0.6.0"
 anyhow = "1.0.69"
-sqlx = { version = "0.6.2", features = [ "json", "runtime-tokio-native-tls" , "postgres", "time", "offline" ] }
+sqlx = { version = "0.6.2", features = [ "chrono", "json", "runtime-tokio-native-tls" , "postgres", "time", "offline" ] }
 url = "2.3.1"
 thiserror = "1.0.39"
 semver = { version = "1.0.16", features = ["serde"] }
 serde = { version = "1.0.154", features = ["derive"] }
 futures = "0.3.26"
 serde_json = "1.0.94"
-chrono = "0.4.23"
+chrono = { version = "0.4.23", features = [ "serde" ] }
 dotenv = "0.15.0"
 env_logger = "0.10.0"
 reqwest = "0.11.14"

--- a/registry/justfile
+++ b/registry/justfile
@@ -10,7 +10,7 @@ run-migrations:
 
 run:
     RUST_LOG=debug \
-    DATABASE_URL=${DATABASE_URL} \
+    DATABASE_URL=postgresql://postgres:postgres@0.0.0.0:5432/postgres \
     RUST_BACKTRACE=full \
     RUST_LOG=debug \
     cargo run

--- a/registry/justfile
+++ b/registry/justfile
@@ -10,7 +10,7 @@ run-migrations:
 
 run:
     RUST_LOG=debug \
-    DATABASE_URL=postgresql://postgres:postgres@0.0.0.0:5432/postgres \
+    DATABASE_URL=${DATABASE_URL} \
     RUST_BACKTRACE=full \
     RUST_LOG=debug \
     cargo run

--- a/registry/migrations/20230919195237_extensions_detail_vw.sql
+++ b/registry/migrations/20230919195237_extensions_detail_vw.sql
@@ -34,4 +34,5 @@ GROUP BY
     e.homepage, 
     e.documentation, 
     e.repository, 
-    lv.license;
+    lv.license
+ORDER BY "name" ASC;

--- a/registry/migrations/20230919195237_extensions_detail_vw.sql
+++ b/registry/migrations/20230919195237_extensions_detail_vw.sql
@@ -1,0 +1,37 @@
+-- query that returns the latest version of each extension
+create view extension_detail_vw as 
+WITH latest_versions AS (
+    SELECT
+        v.extension_id,
+        v.num AS latest_version,
+        v.license,
+        ROW_NUMBER() OVER(PARTITION BY v.extension_id ORDER BY v.updated_at DESC) AS rn
+    FROM public.versions v
+)
+SELECT
+    e."name" AS extension_name,
+    lv.latest_version,
+    e.created_at,
+    e.updated_at,
+    e.description,
+    e.homepage,
+    e.documentation,
+    e.repository,
+    lv.license,
+    jsonb_agg(DISTINCT eo.user_name) AS owners,
+    jsonb_agg(DISTINCT cg.name) AS categories
+FROM public.extensions e
+LEFT JOIN latest_versions lv ON e.id = lv.extension_id AND lv.rn = 1
+LEFT JOIN public.extension_owners eo ON e.id = eo.extension_id AND eo.deleted = false
+LEFT JOIN public.extensions_categories ec ON e.id = ec.extension_id
+left join public.categories cg on ec.category_id  = cg.id
+GROUP BY 
+    e."name", 
+    lv.latest_version, 
+    e.created_at, 
+    e.updated_at, 
+    e.description, 
+    e.homepage, 
+    e.documentation, 
+    e.repository, 
+    lv.license

--- a/registry/migrations/20230919195237_extensions_detail_vw.sql
+++ b/registry/migrations/20230919195237_extensions_detail_vw.sql
@@ -10,9 +10,9 @@ WITH latest_versions AS (
 )
 SELECT
     e."name" AS "name",
-    lv.latest_version,
-    e.created_at,
-    e.updated_at,
+    lv.latest_version as "latestVersion",
+    e.created_at as "createdAt",
+    e.updated_at as "updatedAt",
     e.description,
     e.homepage,
     e.documentation,

--- a/registry/migrations/20230919195237_extensions_detail_vw.sql
+++ b/registry/migrations/20230919195237_extensions_detail_vw.sql
@@ -34,4 +34,4 @@ GROUP BY
     e.homepage, 
     e.documentation, 
     e.repository, 
-    lv.license
+    lv.license;

--- a/registry/migrations/20230919195237_extensions_detail_vw.sql
+++ b/registry/migrations/20230919195237_extensions_detail_vw.sql
@@ -9,7 +9,7 @@ WITH latest_versions AS (
     FROM public.versions v
 )
 SELECT
-    e."name" AS extension_name,
+    e."name" AS "name",
     lv.latest_version,
     e.created_at,
     e.updated_at,

--- a/registry/migrations/20230919195237_extensions_detail_vw.sql
+++ b/registry/migrations/20230919195237_extensions_detail_vw.sql
@@ -18,7 +18,7 @@ SELECT
     e.documentation,
     e.repository,
     lv.license,
-    jsonb_agg(DISTINCT eo.user_name) AS owners,
+    jsonb_agg(DISTINCT jsonb_build_object('userName', eo.user_name, 'userId', eo.owner_id)) FILTER (WHERE eo.user_name IS NOT NULL) AS owners,
     jsonb_agg(DISTINCT cg.name) AS categories
 FROM public.extensions e
 LEFT JOIN latest_versions lv ON e.id = lv.extension_id AND lv.rn = 1

--- a/registry/migrations/20230919195237_extensions_detail_vw.sql
+++ b/registry/migrations/20230919195237_extensions_detail_vw.sql
@@ -1,5 +1,5 @@
 -- query that returns the latest version of each extension
-create view extension_detail_vw as 
+create or replace view extension_detail_vw as 
 WITH latest_versions AS (
     SELECT
         v.extension_id,

--- a/registry/sqlx-data.json
+++ b/registry/sqlx-data.json
@@ -1152,17 +1152,17 @@
           "type_info": "Varchar"
         },
         {
-          "name": "latest_version",
+          "name": "latestVersion",
           "ordinal": 1,
           "type_info": "Varchar"
         },
         {
-          "name": "created_at",
+          "name": "createdAt",
           "ordinal": 2,
           "type_info": "Timestamptz"
         },
         {
-          "name": "updated_at",
+          "name": "updatedAt",
           "ordinal": 3,
           "type_info": "Timestamptz"
         },

--- a/registry/sqlx-data.json
+++ b/registry/sqlx-data.json
@@ -1147,7 +1147,7 @@
     "describe": {
       "columns": [
         {
-          "name": "extension_name",
+          "name": "name",
           "ordinal": 0,
           "type_info": "Varchar"
         },

--- a/registry/sqlx-data.json
+++ b/registry/sqlx-data.json
@@ -1143,7 +1143,7 @@
     },
     "query": "DELETE FROM extension_owners\n             WHERE extension_id = $1"
   },
-  "daeaa868ffbd7914b8504237e347279ccffb11d75f85b8d128d83ea271b847d5": {
+  "c390e218569ef66621ae5e01addfe5ee1d83cd86496f388846604862bd3510c4": {
     "describe": {
       "columns": [
         {
@@ -1194,32 +1194,32 @@
         {
           "name": "owners",
           "ordinal": 9,
-          "type_info": "VarcharArray"
+          "type_info": "Jsonb"
         },
         {
           "name": "categories",
           "ordinal": 10,
-          "type_info": "VarcharArray"
+          "type_info": "Jsonb"
         }
       ],
       "nullable": [
         true,
         true,
-        false,
-        false,
         true,
         true,
         true,
         true,
         true,
-        null,
-        null
+        true,
+        true,
+        true,
+        true
       ],
       "parameters": {
         "Left": []
       }
     },
-    "query": "WITH latest_versions AS (\n            SELECT\n                v.extension_id,\n                v.num AS latest_version,\n                v.license,\n                ROW_NUMBER() OVER(PARTITION BY v.extension_id ORDER BY v.updated_at DESC) AS rn\n            FROM public.versions v\n        )\n        SELECT\n            e.\"name\" AS extension_name,\n            lv.latest_version,\n            e.created_at,\n            e.updated_at,\n            e.description,\n            e.homepage,\n            e.documentation,\n            e.repository,\n            lv.license,\n            array_agg(DISTINCT eo.user_name) AS owners,\n            array_agg(DISTINCT cg.name) AS categories\n        FROM public.extensions e\n        LEFT JOIN latest_versions lv ON e.id = lv.extension_id AND lv.rn = 1\n        LEFT JOIN public.extension_owners eo ON e.id = eo.extension_id AND eo.deleted = false\n        LEFT JOIN public.extensions_categories ec ON e.id = ec.extension_id\n        left join public.categories cg on ec.category_id  = cg.id\n        GROUP BY \n            e.\"name\", \n            lv.latest_version, \n            e.created_at, \n            e.updated_at, \n            e.description, \n            e.homepage, \n            e.documentation, \n            e.repository, \n            lv.license;"
+    "query": "SELECT * FROM extension_detail_vw"
   },
   "e41ccd0b4b07c1761d78d4de2efdba33979114f1b055db3261af653afca8be56": {
     "describe": {

--- a/registry/sqlx-data.json
+++ b/registry/sqlx-data.json
@@ -1143,6 +1143,84 @@
     },
     "query": "DELETE FROM extension_owners\n             WHERE extension_id = $1"
   },
+  "daeaa868ffbd7914b8504237e347279ccffb11d75f85b8d128d83ea271b847d5": {
+    "describe": {
+      "columns": [
+        {
+          "name": "extension_name",
+          "ordinal": 0,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "latest_version",
+          "ordinal": 1,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 2,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "updated_at",
+          "ordinal": 3,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "description",
+          "ordinal": 4,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "homepage",
+          "ordinal": 5,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "documentation",
+          "ordinal": 6,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "repository",
+          "ordinal": 7,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "license",
+          "ordinal": 8,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "owners",
+          "ordinal": 9,
+          "type_info": "VarcharArray"
+        },
+        {
+          "name": "categories",
+          "ordinal": 10,
+          "type_info": "VarcharArray"
+        }
+      ],
+      "nullable": [
+        true,
+        true,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        true,
+        null,
+        null
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "WITH latest_versions AS (\n            SELECT\n                v.extension_id,\n                v.num AS latest_version,\n                v.license,\n                ROW_NUMBER() OVER(PARTITION BY v.extension_id ORDER BY v.updated_at DESC) AS rn\n            FROM public.versions v\n        )\n        SELECT\n            e.\"name\" AS extension_name,\n            lv.latest_version,\n            e.created_at,\n            e.updated_at,\n            e.description,\n            e.homepage,\n            e.documentation,\n            e.repository,\n            lv.license,\n            array_agg(DISTINCT eo.user_name) AS owners,\n            array_agg(DISTINCT cg.name) AS categories\n        FROM public.extensions e\n        LEFT JOIN latest_versions lv ON e.id = lv.extension_id AND lv.rn = 1\n        LEFT JOIN public.extension_owners eo ON e.id = eo.extension_id AND eo.deleted = false\n        LEFT JOIN public.extensions_categories ec ON e.id = ec.extension_id\n        left join public.categories cg on ec.category_id  = cg.id\n        GROUP BY \n            e.\"name\", \n            lv.latest_version, \n            e.created_at, \n            e.updated_at, \n            e.description, \n            e.homepage, \n            e.documentation, \n            e.repository, \n            lv.license;"
+  },
   "e41ccd0b4b07c1761d78d4de2efdba33979114f1b055db3261af653afca8be56": {
     "describe": {
       "columns": [],

--- a/registry/src/routes/extensions.rs
+++ b/registry/src/routes/extensions.rs
@@ -308,70 +308,37 @@ pub struct ExtensionOwner {
     pub user_name: String,
 }
 
-#[derive(Serialize)]
+use sqlx::types::chrono::Utc;
+
+#[derive(Debug, Serialize)]
 pub struct ExtensionDetails {
     pub extension_name: Option<String>,
-    #[serde(rename = "camelCase")]
     pub latest_version: Option<String>,
-    #[serde(rename = "camelCase")]
-    pub created_at: time::OffsetDateTime,
-    #[serde(rename = "camelCase")]
-    pub updated_at: time::OffsetDateTime,
+    pub created_at: Option<chrono::DateTime<Utc>>,
+    pub updated_at: Option<chrono::DateTime<Utc>>,
     pub description: Option<String>,
     pub homepage: Option<String>,
     pub documentation: Option<String>,
     pub repository: Option<String>,
     pub license: Option<String>,
-    pub owners: Option<Vec<String>>,
-    pub categories: Option<Vec<String>>,
+    pub owners: Option<Value>,
+    pub categories: Option<Value>,
 }
 
 #[get("beta/extensions/all")]
 pub async fn beta_get_all_extensions(
     conn: web::Data<Pool<Postgres>>,
 ) -> Result<HttpResponse, ExtensionRegistryError> {
-    let rows = sqlx::query_as!(
-        ExtensionDetails,
-        r#"WITH latest_versions AS (
-            SELECT
-                v.extension_id,
-                v.num AS latest_version,
-                v.license,
-                ROW_NUMBER() OVER(PARTITION BY v.extension_id ORDER BY v.updated_at DESC) AS rn
-            FROM public.versions v
-        )
-        SELECT
-            e."name" AS extension_name,
-            lv.latest_version,
-            e.created_at,
-            e.updated_at,
-            e.description,
-            e.homepage,
-            e.documentation,
-            e.repository,
-            lv.license,
-            array_agg(DISTINCT eo.user_name) AS owners,
-            array_agg(DISTINCT cg.name) AS categories
-        FROM public.extensions e
-        LEFT JOIN latest_versions lv ON e.id = lv.extension_id AND lv.rn = 1
-        LEFT JOIN public.extension_owners eo ON e.id = eo.extension_id AND eo.deleted = false
-        LEFT JOIN public.extensions_categories ec ON e.id = ec.extension_id
-        left join public.categories cg on ec.category_id  = cg.id
-        GROUP BY 
-            e."name", 
-            lv.latest_version, 
-            e.created_at, 
-            e.updated_at, 
-            e.description, 
-            e.homepage, 
-            e.documentation, 
-            e.repository, 
-            lv.license;"#
-    )
-    .fetch_all(conn.get_ref())
-    .await?;
-
-    Ok(HttpResponse::Ok().json(rows))
+    match sqlx::query_as!(ExtensionDetails, "SELECT * FROM extension_detail_vw")
+        .fetch_all(conn.get_ref())
+        .await
+    {
+        Ok(extensions) => Ok(HttpResponse::Ok().json(extensions)),
+        Err(e) => {
+            error!("Error fetching extensions: {}", e);
+            Err(ExtensionRegistryError::from(e))
+        }
+    }
 }
 
 #[get("/extensions/all")]

--- a/registry/src/routes/extensions.rs
+++ b/registry/src/routes/extensions.rs
@@ -312,17 +312,17 @@ use sqlx::types::chrono::Utc;
 
 #[derive(Debug, Serialize)]
 pub struct ExtensionDetails {
-    pub extension_name: Option<String>,
-    pub latest_version: Option<String>,
-    pub created_at: Option<chrono::DateTime<Utc>>,
-    pub updated_at: Option<chrono::DateTime<Utc>>,
-    pub description: Option<String>,
-    pub homepage: Option<String>,
-    pub documentation: Option<String>,
-    pub repository: Option<String>,
-    pub license: Option<String>,
-    pub owners: Option<Value>,
     pub categories: Option<Value>,
+    pub created_at: Option<chrono::DateTime<Utc>>,
+    pub description: Option<String>,
+    pub documentation: Option<String>,
+    pub homepage: Option<String>,
+    pub latest_version: Option<String>,
+    pub license: Option<String>,
+    pub name: Option<String>,
+    pub owners: Option<Value>,
+    pub repository: Option<String>,
+    pub updated_at: Option<chrono::DateTime<Utc>>,
 }
 
 #[get("beta/extensions/all")]

--- a/registry/src/routes/extensions.rs
+++ b/registry/src/routes/extensions.rs
@@ -20,7 +20,9 @@ use aws_config::SdkConfig;
 use aws_sdk_s3;
 use aws_sdk_s3::primitives::ByteStream;
 use futures::TryStreamExt;
+use serde::ser::Serializer;
 use serde_json::{json, Value};
+use sqlx::types::chrono::Utc;
 use sqlx::{Pool, Postgres};
 use tracing::{error, info};
 
@@ -308,21 +310,38 @@ pub struct ExtensionOwner {
     pub user_name: String,
 }
 
-use sqlx::types::chrono::Utc;
-
+#[allow(non_snake_case)]
 #[derive(Debug, Serialize)]
 pub struct ExtensionDetails {
     pub categories: Option<Value>,
-    pub created_at: Option<chrono::DateTime<Utc>>,
+    #[serde(serialize_with = "serialize_with_offset")]
+    pub createdAt: Option<chrono::DateTime<Utc>>,
     pub description: Option<String>,
     pub documentation: Option<String>,
     pub homepage: Option<String>,
-    pub latest_version: Option<String>,
+    pub latestVersion: Option<String>,
     pub license: Option<String>,
     pub name: Option<String>,
     pub owners: Option<Value>,
     pub repository: Option<String>,
-    pub updated_at: Option<chrono::DateTime<Utc>>,
+    #[serde(serialize_with = "serialize_with_offset")]
+    pub updatedAt: Option<chrono::DateTime<Utc>>,
+}
+
+fn serialize_with_offset<S>(
+    date: &Option<chrono::DateTime<Utc>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match date {
+        Some(d) => {
+            let s = d.to_rfc3339();
+            serializer.serialize_str(&s)
+        }
+        None => serializer.serialize_none(),
+    }
 }
 
 #[get("beta/extensions/all")]

--- a/registry/src/server.rs
+++ b/registry/src/server.rs
@@ -10,6 +10,7 @@ pub fn routes_config(configuration: &mut web::ServiceConfig) {
     let clerk_cfg = ClerkConfiguration::new(None, None, Some(cfg.clerk_secret_key), None);
     configuration
         .service(routes::root::ok)
+        .service(routes::extensions::beta_get_all_extensions)
         .service(routes::extensions::get_all_extensions)
         .service(routes::extensions::get_version)
         .service(routes::extensions::get_version_history)

--- a/registry/tests/integration_test.rs
+++ b/registry/tests/integration_test.rs
@@ -10,7 +10,7 @@ mod tests {
     use trunk_registry::connect;
     use trunk_registry::routes::categories::get_all_categories;
     use trunk_registry::routes::download::download;
-    use trunk_registry::routes::extensions::get_all_extensions;
+    use trunk_registry::routes::extensions::{beta_get_all_extensions, get_all_extensions};
     use trunk_registry::routes::root::ok;
     use trunk_registry::routes::token::new_token;
     use trunk_registry::token::check_token_input;
@@ -48,6 +48,7 @@ mod tests {
                 .app_data(web::Data::new(cfg.clone()))
                 .service(ok)
                 .service(get_all_extensions)
+                .service(beta_get_all_extensions)
                 .service(get_all_categories)
                 .service(download)
                 .service(web::scope("/token").service(new_token)),


### PR DESCRIPTION
@ChuckHend figured out a way to speed up `/extensions/all` with a single query

This PR proposes adding this new code under a new temporary endpoint for testing.
If the testing goes well, removing the older code would be very straightforward