### PR TITLE
registry: wire `/admin/extensions/libraries/{library}` into server

### DIFF
--- a/registry/sqlx-data.json
+++ b/registry/sqlx-data.json
@@ -612,18 +612,6 @@
     },
     "query": "SELECT id FROM extensions WHERE name = $1"
   },
-  "61aeafaa53e3b42eba21e4231a429fd15eb2a47419141f8e4a2e48950296d974": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "Varchar"
-        ]
-      }
-    },
-    "query": "INSERT INTO shared_preload_libraries(name) VALUES ($1)"
-  },
   "69ef7c7c79e69f31731a41417a0047562f0806a7c73eb4bb98c9ed554fff3b7c": {
     "describe": {
       "columns": [],
@@ -1130,6 +1118,18 @@
       }
     },
     "query": "SELECT * FROM versions WHERE extension_id = $1 AND num = $2"
+  },
+  "bd184a09a0f45acc606a45ef90e0e41c500128881c1284374823f53c978b527d": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Varchar"
+        ]
+      }
+    },
+    "query": "INSERT INTO shared_preload_libraries(name)\n        VALUES ($1)\n        ON CONFLICT (name) DO NOTHING;"
   },
   "bdd38a42eae77d1ff93284a7a26973190408d533f19a7972bd9932c7204f5e33": {
     "describe": {

--- a/registry/src/routes/extensions.rs
+++ b/registry/src/routes/extensions.rs
@@ -480,7 +480,9 @@ pub async fn put_shared_preload_libraries(
 ) -> Result<HttpResponse, ExtensionRegistryError> {
     let library = path.into_inner();
     sqlx::query!(
-        "INSERT INTO shared_preload_libraries(name) VALUES ($1)",
+        "INSERT INTO shared_preload_libraries(name)
+        VALUES ($1)
+        ON CONFLICT (name) DO NOTHING;",
         &library
     )
     .execute(conn.as_ref())

--- a/registry/src/server.rs
+++ b/registry/src/server.rs
@@ -26,7 +26,8 @@ pub fn routes_config(configuration: &mut web::ServiceConfig) {
             web::scope("/admin")
                 .wrap(ClerkMiddleware::new(clerk_cfg, None))
                 .service(routes::root::auth_ok)
-                .service(routes::extensions::delete_extension),
+                .service(routes::extensions::delete_extension)
+                .service(routes::extensions::put_shared_preload_libraries),
         );
 }
 


### PR DESCRIPTION
Also ensures that repeated extensions cannot be inserted