### PR TITLE
Update jsonb_plperl_u dockerfile with libjson-perl

### DIFF
--- a/contrib/jsonb_plperl/Dockerfile
+++ b/contrib/jsonb_plperl/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache \
 	libperl-dev \
-	perl
+	perl \
+	libjson-perl
 
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git

--- a/contrib/jsonb_plperlu/Dockerfile
+++ b/contrib/jsonb_plperlu/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache \
 	libperl-dev \
-	perl
+	perl \
+	libjson-perl
 
 # Clone repository
 RUN git clone https://github.com/postgres/postgres.git


### PR DESCRIPTION
Address the following error by introducing `libjson-perl` to the Dockerfiles of `jsonb_plperl` and `jsonb_plperlu`

`ERROR:  Unable to load JSON.pm into plperl at line 2.`
