### PR TITLE
registry: keep track of download counts

### DIFF
--- a/registry/migrations/20231012133409_add-download-count.sql
+++ b/registry/migrations/20231012133409_add-download-count.sql
@@ -1,0 +1,11 @@
+ALTER TABLE versions
+ADD COLUMN download_count integer NOT NULL DEFAULT 0;
+
+UPDATE versions
+SET download_count = COALESCE(downloads, 0);
+
+ALTER TABLE versions
+DROP COLUMN downloads;
+
+ALTER TABLE extensions
+DROP COLUMN downloads;

--- a/registry/sqlx-data.json
+++ b/registry/sqlx-data.json
@@ -524,28 +524,23 @@
           "type_info": "Timestamptz"
         },
         {
-          "name": "downloads",
-          "ordinal": 4,
-          "type_info": "Int4"
-        },
-        {
           "name": "description",
-          "ordinal": 5,
+          "ordinal": 4,
           "type_info": "Varchar"
         },
         {
           "name": "homepage",
-          "ordinal": 6,
+          "ordinal": 5,
           "type_info": "Varchar"
         },
         {
           "name": "documentation",
-          "ordinal": 7,
+          "ordinal": 6,
           "type_info": "Varchar"
         },
         {
           "name": "repository",
-          "ordinal": 8,
+          "ordinal": 7,
           "type_info": "Varchar"
         }
       ],
@@ -554,7 +549,6 @@
         true,
         false,
         false,
-        true,
         true,
         true,
         true,
@@ -684,59 +678,59 @@
           "type_info": "Timestamptz"
         },
         {
-          "name": "downloads",
-          "ordinal": 5,
-          "type_info": "Int4"
-        },
-        {
           "name": "features",
-          "ordinal": 6,
+          "ordinal": 5,
           "type_info": "Jsonb"
         },
         {
           "name": "yanked",
-          "ordinal": 7,
+          "ordinal": 6,
           "type_info": "Bool"
         },
         {
           "name": "license",
-          "ordinal": 8,
+          "ordinal": 7,
           "type_info": "Varchar"
         },
         {
           "name": "extension_size",
-          "ordinal": 9,
+          "ordinal": 8,
           "type_info": "Int4"
         },
         {
           "name": "published_by",
-          "ordinal": 10,
+          "ordinal": 9,
           "type_info": "Varchar"
         },
         {
           "name": "checksum",
-          "ordinal": 11,
+          "ordinal": 10,
           "type_info": "Bpchar"
         },
         {
           "name": "links",
-          "ordinal": 12,
+          "ordinal": 11,
           "type_info": "Varchar"
         },
         {
           "name": "extension_name",
-          "ordinal": 13,
+          "ordinal": 12,
           "type_info": "Varchar"
         },
         {
           "name": "system_dependencies",
-          "ordinal": 14,
+          "ordinal": 13,
           "type_info": "Jsonb"
         },
         {
           "name": "libraries",
-          "ordinal": 15,
+          "ordinal": 14,
           "type_info": "Jsonb"
+        },
+        {
+          "name": "download_count",
+          "ordinal": 15,
+          "type_info": "Int4"
         }
       ],
       "nullable": [
@@ -755,7 +749,7 @@
         true,
         true,
         true,
-        true
+        false
       ],
       "parameters": {
         "Left": [
@@ -795,59 +789,59 @@
           "type_info": "Timestamptz"
         },
         {
-          "name": "downloads",
-          "ordinal": 5,
-          "type_info": "Int4"
-        },
-        {
           "name": "features",
-          "ordinal": 6,
+          "ordinal": 5,
           "type_info": "Jsonb"
         },
         {
           "name": "yanked",
-          "ordinal": 7,
+          "ordinal": 6,
           "type_info": "Bool"
         },
         {
           "name": "license",
-          "ordinal": 8,
+          "ordinal": 7,
           "type_info": "Varchar"
         },
         {
           "name": "extension_size",
-          "ordinal": 9,
+          "ordinal": 8,
           "type_info": "Int4"
         },
         {
           "name": "published_by",
-          "ordinal": 10,
+          "ordinal": 9,
           "type_info": "Varchar"
         },
         {
           "name": "checksum",
-          "ordinal": 11,
+          "ordinal": 10,
           "type_info": "Bpchar"
         },
         {
           "name": "links",
-          "ordinal": 12,
+          "ordinal": 11,
           "type_info": "Varchar"
         },
         {
           "name": "extension_name",
-          "ordinal": 13,
+          "ordinal": 12,
           "type_info": "Varchar"
         },
         {
           "name": "system_dependencies",
-          "ordinal": 14,
+          "ordinal": 13,
           "type_info": "Jsonb"
         },
         {
           "name": "libraries",
-          "ordinal": 15,
+          "ordinal": 14,
           "type_info": "Jsonb"
+        },
+        {
+          "name": "download_count",
+          "ordinal": 15,
+          "type_info": "Int4"
         }
       ],
       "nullable": [
@@ -866,7 +860,7 @@
         true,
         true,
         true,
-        true
+        false
       ],
       "parameters": {
         "Left": [
@@ -943,6 +937,27 @@
     },
     "query": "DELETE FROM extensions_categories\n                 WHERE extension_id = $1\n                 RETURNING category_id\n                 "
   },
+  "9921932de47d84b6a79a6f5fb29b77301d8a3a2e9acefbc97612952da86e6887": {
+    "describe": {
+      "columns": [
+        {
+          "name": "version_exists",
+          "ordinal": 0,
+          "type_info": "Bool"
+        }
+      ],
+      "nullable": [
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Int4",
+          "Text"
+        ]
+      }
+    },
+    "query": "SELECT COUNT(*) > 0 AS version_exists\n        FROM versions\n        WHERE extension_id = $1\n        AND num = $2"
+  },
   "a355d51ccf9b49a96bf62078f00fb982ba11a3026d8b9f120d948b6c5e40d317": {
     "describe": {
       "columns": [],
@@ -1010,59 +1025,59 @@
           "type_info": "Timestamptz"
         },
         {
-          "name": "downloads",
-          "ordinal": 5,
-          "type_info": "Int4"
-        },
-        {
           "name": "features",
-          "ordinal": 6,
+          "ordinal": 5,
           "type_info": "Jsonb"
         },
         {
           "name": "yanked",
-          "ordinal": 7,
+          "ordinal": 6,
           "type_info": "Bool"
         },
         {
           "name": "license",
-          "ordinal": 8,
+          "ordinal": 7,
           "type_info": "Varchar"
         },
         {
           "name": "extension_size",
-          "ordinal": 9,
+          "ordinal": 8,
           "type_info": "Int4"
         },
         {
           "name": "published_by",
-          "ordinal": 10,
+          "ordinal": 9,
           "type_info": "Varchar"
         },
         {
           "name": "checksum",
-          "ordinal": 11,
+          "ordinal": 10,
           "type_info": "Bpchar"
         },
         {
           "name": "links",
-          "ordinal": 12,
+          "ordinal": 11,
           "type_info": "Varchar"
         },
         {
           "name": "extension_name",
-          "ordinal": 13,
+          "ordinal": 12,
           "type_info": "Varchar"
         },
         {
           "name": "system_dependencies",
-          "ordinal": 14,
+          "ordinal": 13,
           "type_info": "Jsonb"
         },
         {
           "name": "libraries",
-          "ordinal": 15,
+          "ordinal": 14,
           "type_info": "Jsonb"
+        },
+        {
+          "name": "download_count",
+          "ordinal": 15,
+          "type_info": "Int4"
         }
       ],
       "nullable": [
@@ -1081,7 +1096,7 @@
         true,
         true,
         true,
-        true
+        false
       ],
       "parameters": {
         "Left": [
@@ -1244,5 +1259,17 @@
       }
     },
     "query": "\n            UPDATE categories\n            SET extension_count = extension_count + 1\n            WHERE id = $1\n            "
+  },
+  "f77d6c607d830e7ea1d564c34ec42b998e0c2657f4cdb8a89dd211a29b4a7d65": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Int4"
+        ]
+      }
+    },
+    "query": "UPDATE versions\n        SET download_count = download_count + 1\n        WHERE extension_id = $1"
   }
 }

--- a/registry/src/download.rs
+++ b/registry/src/download.rs
@@ -1,12 +1,11 @@
 //! Functionality for downloading extensions and maintaining download counts
 use crate::errors::ExtensionRegistryError;
-use actix_web::web;
 use sqlx::{Pool, Postgres};
 
 /// Find an extension's lastest version given it's extension_id
 pub async fn latest_version(
     extension_id: i32,
-    conn: web::Data<Pool<Postgres>>,
+    conn: &Pool<Postgres>,
 ) -> Result<String, ExtensionRegistryError> {
     // Create a transaction on the database
     let mut tx = conn.begin().await?;
@@ -14,4 +13,23 @@ pub async fn latest_version(
         .fetch_one(&mut tx)
         .await?;
     Ok(latest.num.unwrap())
+}
+
+pub async fn check_version(
+    pool: &Pool<Postgres>,
+    extension_id: i32,
+    version: &str,
+) -> Result<bool, ExtensionRegistryError> {
+    let record = sqlx::query!(
+        "SELECT COUNT(*) > 0 AS version_exists
+        FROM versions
+        WHERE extension_id = $1
+        AND num = $2",
+        extension_id,
+        version
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(record.version_exists.unwrap_or(false))
 }

--- a/registry/src/routes/download.rs
+++ b/registry/src/routes/download.rs
@@ -1,6 +1,6 @@
 //! Functionality for downloading extensions and maintaining download counts
-use crate::download::latest_version;
-use crate::errors::ExtensionRegistryError;
+use crate::download::{check_version, latest_version};
+use crate::errors::Result;
 use crate::uploader::extension_location;
 use crate::{config::Config, extensions::get_extension_id};
 use actix_web::{get, web, HttpResponse};
@@ -14,16 +14,38 @@ pub async fn download(
     conn: web::Data<Pool<Postgres>>,
     cfg: web::Data<Config>,
     path: web::Path<(String, String)>,
-) -> Result<HttpResponse, ExtensionRegistryError> {
+) -> Result<HttpResponse> {
     let (name, mut version) = path.into_inner();
-    // TODO(ianstanton) Increment download count for extension
+    let extension_id = get_extension_id(&name, conn.as_ref()).await?;
+
     // Use latest version if 'latest' provided as version
     if version == "latest" {
-        let extension_id = get_extension_id(&name, conn.as_ref()).await?;
-        version = latest_version(extension_id as _, conn).await?;
+        version = latest_version(extension_id as _, conn.as_ref()).await?;
+    } else {
+        let version_exists = check_version(conn.as_ref(), extension_id as _, &version).await?;
+        if !version_exists {
+            return Ok(HttpResponse::NotFound().body("Version not found"));
+        }
     }
     let url = extension_location(&cfg.bucket_name, &name, &version);
-    info!("Download requested for {} version {}", name, version);
-    info!("URL: {}", url);
+    info!(
+        "Download requested for {} version {}. URL: {}",
+        name, version, url
+    );
+    increase_download_count(conn.as_ref(), extension_id as _).await?;
+
     Ok(HttpResponse::Ok().body(url))
+}
+
+async fn increase_download_count(pool: &Pool<Postgres>, extension_id: i32) -> Result {
+    sqlx::query!(
+        "UPDATE versions
+        SET download_count = download_count + 1
+        WHERE extension_id = $1",
+        extension_id
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(())
 }

--- a/registry/src/routes/download.rs
+++ b/registry/src/routes/download.rs
@@ -23,6 +23,7 @@ pub async fn download(
         version = latest_version(extension_id as _, conn.as_ref()).await?;
     } else {
         let version_exists = check_version(conn.as_ref(), extension_id as _, &version).await?;
+
         if !version_exists {
             return Ok(HttpResponse::NotFound().body("Version not found"));
         }

--- a/registry/tests/integration_test.rs
+++ b/registry/tests/integration_test.rs
@@ -33,6 +33,8 @@ mod tests {
         let dummy_jwt = "Bearer eyJhbGciOiJIUzI1NiIsImtpZCI6Imluc18yTzgzQnVQM2ZvS3dHc1o3Tks5b1pVT0lrNkQiLCJ0eXAiOiJKV1QifQ.eyJhenAiOiJodHRwOi8vbG9jYWxob3N0OjMwMDAiLCJleHAiOjE2ODM1OTU0ODMsImlhdCI6MTY4MzU5NTQyMywiaXNzIjoiaHR0cHM6Ly9lbGVjdHJpYy1jcmFwcGllLTkyLmNsZXJrLmFjY291bnRzLmRldiIsImp0aSI6Ijg3ZTFjOTc5MTBmYzA5N2E1MDlkIiwibmJmIjoxNjgzNTk1NDEzLCJzaWQiOiJzZXNzXzJQWEZHRU9pSWJvM2U5cUpqYk01c3BkdW1teSIsInN1YiI6InVzZXJfMlBIbVgzWVBqbmpOV1VsMTZMR1FUbGR1bW15IiwidXNlck5hbWUiOiJkdW1teSJ9.a70cMX7g_asjO4O5oG3ym16KTyuGRsy21fHScriZms0";
 
         std::env::set_var("GITHUB_TOKEN", "dummy");
+        std::env::set_var("CLERK_SECRET_KEY", "dummy");
+
         let cfg = trunk_registry::config::Config::default();
         let conn = connect(&cfg.database_url)
             .await

--- a/registry/tests/integration_test.rs
+++ b/registry/tests/integration_test.rs
@@ -28,7 +28,7 @@ mod tests {
     /// make sure the webserver boots up
     #[actix_web::test]
     async fn test_get_all_extensions() {
-        env_logger::init();
+        tracing_subscriber::fmt::init();
 
         let dummy_jwt = "Bearer eyJhbGciOiJIUzI1NiIsImtpZCI6Imluc18yTzgzQnVQM2ZvS3dHc1o3Tks5b1pVT0lrNkQiLCJ0eXAiOiJKV1QifQ.eyJhenAiOiJodHRwOi8vbG9jYWxob3N0OjMwMDAiLCJleHAiOjE2ODM1OTU0ODMsImlhdCI6MTY4MzU5NTQyMywiaXNzIjoiaHR0cHM6Ly9lbGVjdHJpYy1jcmFwcGllLTkyLmNsZXJrLmFjY291bnRzLmRldiIsImp0aSI6Ijg3ZTFjOTc5MTBmYzA5N2E1MDlkIiwibmJmIjoxNjgzNTk1NDEzLCJzaWQiOiJzZXNzXzJQWEZHRU9pSWJvM2U5cUpqYk01c3BkdW1teSIsInN1YiI6InVzZXJfMlBIbVgzWVBqbmpOV1VsMTZMR1FUbGR1bW15IiwidXNlck5hbWUiOiJkdW1teSJ9.a70cMX7g_asjO4O5oG3ym16KTyuGRsy21fHScriZms0";
 
@@ -44,6 +44,35 @@ mod tests {
             .run(&conn)
             .await
             .expect("error running migrations");
+
+        let created_extension = sqlx::query!(
+            "INSERT INTO extensions (
+            name,
+            updated_at,
+            created_at
+        ) VALUES (
+            'my_extension',
+            now() AT TIME ZONE 'UTC',
+            now() AT TIME ZONE 'UTC')
+         RETURNING id
+        "
+        )
+        .fetch_one(&conn)
+        .await
+        .unwrap();
+
+        sqlx::query!(
+            "INSERT INTO versions (
+                extension_id,
+                num,
+                download_count
+            ) VALUES ($1, $2, 5)",
+            created_extension.id as i32,
+            "0.0.1"
+        )
+        .execute(&conn)
+        .await
+        .unwrap();
 
         let app = test::init_service(
             App::new()


### PR DESCRIPTION
* Starts ticking `download_count` for each version of an extension.

* Makes the endpoint be more strict, refusing to generate URLs for invalid versions, which could happen before this PR

* Updated the integration tests accordingly