### PR TITLE
registry: enforce use of Trunk project name in download route

### DIFF
--- a/registry/sqlx-data.json
+++ b/registry/sqlx-data.json
@@ -676,6 +676,26 @@
     },
     "query": "\n        INSERT INTO extension_owners(extension_id, owner_id, user_name, created_at, created_by)\n        VALUES ($1, $2, $3, (now() at time zone 'utc'), $2)\n        "
   },
+  "756737edb5733514dcb510266ab577703d9cf4cb7f61702d7a4a15962fc8ae87": {
+    "describe": {
+      "columns": [
+        {
+          "name": "name",
+          "ordinal": 0,
+          "type_info": "Varchar"
+        }
+      ],
+      "nullable": [
+        true
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      }
+    },
+    "query": "SELECT name FROM extensions WHERE id = $1"
+  },
   "7a931ec93bcc1516737bfc65fd24b339401996a7f23891c7770a3b5b5c79ffc2": {
     "describe": {
       "columns": [

--- a/registry/src/uploader.rs
+++ b/registry/src/uploader.rs
@@ -11,16 +11,16 @@ use tracing::{debug, info};
 const CACHE_CONTROL_IMMUTABLE: &str = "public,max-age=31536000,immutable";
 
 /// Returns the internal path of an uploaded extension's version archive.
-pub fn extension_path(name: &str, version: &str) -> String {
+fn extension_path(name: &str, version: &str) -> String {
     format!("extensions/{name}/{name}-{version}.tar.gz")
 }
 
 /// Returns the URL of an uploaded extension's version archive.
 ///
 /// The function doesn't check for the existence of the file.
-pub fn extension_location(bucket_name: &str, extension_name: &str, version: &str) -> String {
+pub fn extension_location(bucket_name: &str, project_name: &str, version: &str) -> String {
     let host = format!("{bucket_name}.s3.amazonaws.com");
-    let path = extension_path(extension_name, version);
+    let path = extension_path(project_name, version);
     format!("https://{host}/{path}")
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/tembo-io/trunk/pull/501

The objective is to support (in v1 naming), both Trunk name and extension name in the download route

That is to say, if Trunk attempts to download `pgvector` as `vector`, this endpoint should still succeed.
While #501 made some progress in this front, the download URL being generated is currently wrong, e.g. `https://cdb-plat-use1-prod-pgtrunkio.s3.amazonaws.com/extensions/vector/vector-0.5.1.tar.gz`.

This PR fixes it so that `https://cdb-plat-use1-prod-pgtrunkio.s3.amazonaws.com/extensions/pgvector/pgvector-0.5.1.tar.gz` would be returned.

