### PR TITLE
Typo fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Publish extensions to the registry, making them available to the Postgres commun
 ```
 
 ### `trunk install`
-Downloads Postgres extensions from the Trunk registry and installs into your environment (only Ubuntu suppot at this time).
+Downloads Postgres extensions from the Trunk registry and installs into your environment (only Ubuntu support at this time).
 
 Supports nested dependencies, e.g. installing `extension_a` will automatically install `extension_b` if required.
 


### PR DESCRIPTION
Just noticed this one :)

Might also be nice to point to the source in the rendered site at https://pgt.dev/, like "Edit this page"?