### PR TITLE
Fill in extension view info when control file is absent

### DIFF
--- a/contrib/auto_explain/Trunk.toml
+++ b/contrib/auto_explain/Trunk.toml
@@ -7,9 +7,8 @@ description = "The auto_explain module provides a means for logging execution pl
 homepage = "https://www.postgresql.org"
 documentation = "https://www.postgresql.org/docs/current/auto-explain.html"
 categories = ["featured", "auditing_logging"]
-loadable_libraries = [
-    { library_name = "auto_explain", requires_restart = true, priority = 2147483647 },
-]
+preload_libraries = ["auto_explain"]
+
 [dependencies]
 apt = ["libc6"]
 

--- a/contrib/auto_explain/Trunk.toml
+++ b/contrib/auto_explain/Trunk.toml
@@ -7,8 +7,9 @@ description = "The auto_explain module provides a means for logging execution pl
 homepage = "https://www.postgresql.org"
 documentation = "https://www.postgresql.org/docs/current/auto-explain.html"
 categories = ["featured", "auditing_logging"]
-preload_libraries = ["auto_explain"]
-
+loadable_libraries = [
+    { library_name = "auto_explain", requires_restart = true, priority = 2147483647 },
+]
 [dependencies]
 apt = ["libc6"]
 

--- a/registry/src/v1/extractor.rs
+++ b/registry/src/v1/extractor.rs
@@ -23,29 +23,39 @@ pub fn extract_extension_view(
 ) -> anyhow::Result<Vec<ExtensionView>> {
     let control_files = extract_control_files(tar_gz)?;
 
-    let extension_views = control_files
+    let mut extension_views: Vec<ExtensionView> = control_files
         .into_iter()
         .map(|control_file| ExtensionView {
-            extension_name: control_file.extension_name,
+            extension_name: control_file.extension_name.clone(),
             version: control_file.default_version.unwrap_or_default(),
             trunk_project_name: new_extension.name.to_string(),
             dependencies_extension_names: control_file.dependencies,
             // TODO: should we clone this for every extension in a Trunk project?
             loadable_libraries: new_extension.libraries.clone(),
             configurations: new_extension.configurations.clone(),
-            control_file: if control_file.content.is_none() {
-                Some(ControlFileMetadata {
-                    absent: true,
-                    content: None,
-                })
-            } else {
-                Some(ControlFileMetadata {
-                    absent: false,
-                    content: control_file.content,
-                })
-            },
+            control_file: Some(ControlFileMetadata {
+                absent: false,
+                content: control_file.content,
+            }),
         })
         .collect();
+
+    // If no control files found, we still want to return extension view information we have available.
+    // This includes control_file.absent = true and control_file.content = None
+    if extension_views.is_empty() {
+        extension_views.push(ExtensionView {
+            extension_name: new_extension.extension_name.clone().unwrap_or_default(),
+            version: new_extension.vers.to_string(),
+            trunk_project_name: new_extension.name.to_string(),
+            dependencies_extension_names: None,
+            loadable_libraries: new_extension.libraries.clone(),
+            configurations: new_extension.configurations.clone(),
+            control_file: Some(ControlFileMetadata {
+                absent: true,
+                content: None,
+            }),
+        });
+    }
 
     Ok(extension_views)
 }


### PR DESCRIPTION
Bug fix for when control file is absent. This information was left out when control files were not included in an extension.