### PR TITLE
Fix publish file format bug

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton", "Vinícius Miguel"]
 description = "A package manager for PostgreSQL extensions"

--- a/cli/src/commands/install.rs
+++ b/cli/src/commands/install.rs
@@ -156,14 +156,7 @@ async fn install(
         let bytes = response.bytes().await?;
         dest_file.write_all(&bytes)?;
 
-        install_file(
-            name.clone(),
-            &dest_path,
-            package_lib_dir,
-            sharedir,
-            registry,
-        )
-        .await?;
+        install_file(name, &dest_path, package_lib_dir, sharedir, registry).await?;
     }
     Ok(())
 }


### PR DESCRIPTION
We recently updated the format of our `tar.gz` files to include postgres version. Example:
`auto_explain-15.3.0-pg15.tar.gz`

`trunk publish` was expecting the old format. These changes resolve this issue.