### PR TITLE
Update metadata for extensions without control files

### DIFF
--- a/contrib/auth_delay/Trunk.toml
+++ b/contrib/auth_delay/Trunk.toml
@@ -7,7 +7,7 @@ description = "auth_delay causes the server to pause briefly before reporting au
 homepage = "https://www.postgresql.org"
 documentation = "https://www.postgresql.org/docs/current/auth-delay.html"
 categories = ["security"]
-preload_libraries = ["auth_delay"]
+loadable_libraries = [{ library_name = "auth_delay", requires_restart = true }]
 
 [build]
 postgres_version = "15"

--- a/contrib/basebackup_to_shell/Trunk.toml
+++ b/contrib/basebackup_to_shell/Trunk.toml
@@ -7,7 +7,7 @@ description = "basebackup_to_shell adds a custom basebackup target called shell.
 homepage = "https://www.postgresql.org"
 documentation = "https://www.postgresql.org/docs/current/basebackup-to-shell.html"
 categories = ["tooling_admin"]
-preload_libraries = ["basebackup_to_shell"]
+loadable_libraries = [{ library_name = "basebackup_to_shell", requires_restart = true }]
 
 [dependencies]
 apt = ["libc6"]

--- a/contrib/basic_archive/Trunk.toml
+++ b/contrib/basic_archive/Trunk.toml
@@ -7,7 +7,7 @@ description = "This module copies completed WAL segment files to the specified d
 homepage = "https://www.postgresql.org"
 documentation = "https://www.postgresql.org/docs/current/basic-archive.html"
 categories = ["tooling_admin"]
-preload_libraries = ["basic_archive"]
+loadable_libraries = [{ library_name = "basic_archive", requires_restart = true }]
 
 [dependencies]
 apt = ["libc6"]

--- a/contrib/passwordcheck/Trunk.toml
+++ b/contrib/passwordcheck/Trunk.toml
@@ -7,7 +7,7 @@ description = "The passwordcheck module checks users' passwords whenever they ar
 homepage = "https://www.postgresql.org"
 documentation = "https://www.postgresql.org/docs/current/passwordcheck.html"
 categories = ["security"]
-preload_libraries = ["passwordcheck"]
+loadable_libraries = [{ library_name = "passwordcheck", requires_restart = true }]
 
 [dependencies]
 apt = ["libc6"]

--- a/contrib/pg_anonymize/Trunk.toml
+++ b/contrib/pg_anonymize/Trunk.toml
@@ -6,7 +6,7 @@ license = "GPL-3.0"
 description = "PostgreSQL dynamic data anonymization."
 documentation = "https://github.com/rjuju/pg_anonymize"
 categories = ["security"]
-preload_libraries = ["pg_anonymize"]
+loadable_libraries = [{ library_name = "pg_anonymize", requires_restart = true }]
 
 [dependencies]
 apt = ["libc6"]

--- a/contrib/pg_failover_slots/Trunk.toml
+++ b/contrib/pg_failover_slots/Trunk.toml
@@ -7,7 +7,7 @@ description = "PG Failover Slots avoids the need for you to reseed your logical 
 homepage = "https://www.enterprisedb.com/"
 documentation = "https://www.enterprisedb.com/docs/pg_extensions/pg_failover_slots/"
 categories = ["orchestration"]
-preload_libraries = ["pg_failover_slots"]
+loadable_libraries = [{ library_name = "pg_failover_slots", requires_restart = true }]
 
 [dependencies]
 apt = ["libc6", "libpq5"]

--- a/contrib/sepgsql/Trunk.toml
+++ b/contrib/sepgsql/Trunk.toml
@@ -7,7 +7,7 @@ description = "sepgsql is a loadable module that supports label-based mandatory 
 homepage = "https://www.postgresql.org"
 documentation = "https://www.postgresql.org/docs/current/sepgsql.html"
 categories = ["security"]
-preload_libraries = ["sepgsql"]
+loadable_libraries = [{ library_name = "sepgsql", requires_restart = true }]
 
 [dependencies]
 apt = ["libselinux1", "libc6"]

--- a/contrib/supautils/Trunk.toml
+++ b/contrib/supautils/Trunk.toml
@@ -7,7 +7,7 @@ description = "PostgreSQL extension that prevents doing ALTER/DROP/GRANT on a se
 homepage = "https://supabase.com/"
 documentation = "https://supabase.github.io/supautils/"
 categories = ["tooling_admin"]
-preload_libraries = ["supautils"]
+loadable_libraries = [{ library_name = "supautils", requires_restart = true }]
 
 [dependencies]
 apt = ["libc6"]


### PR DESCRIPTION
The main purpose of this PR is to trigger publish updates for extensions without control files. Their control file metadata will be updated in the Trunk registry. We also needed to update the `preload_libraries` field to `loadable_libraries`, which is convenient.