### PR TITLE
Improve registry testing docs

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -12,48 +12,63 @@ in its database and compiled extension artifacts in AWS S3. Features include:
 ### Extension Categories
 Extensions are grouped according to developer-centric use cases:
 
-`Analytics` - Interrogate data to extract meaningful insights.
+*   `Analytics` - Interrogate data to extract meaningful insights.
 
-`Auditing / Logging` - Monitor and record database activities.
+*   `Auditing / Logging` - Monitor and record database activities.
 
-`Change Data Capture` - Track and apply database changes to targeted objects or processes.
+*   `Change Data Capture` - Track and apply database changes to targeted objects or processes.
 
-`Connectors` - Integrate and interact with external data sources, systems, and services.
+*   `Connectors` - Integrate and interact with external data sources, systems, and services.
 
-`Data / Transformations` - Streamline data loading, transformation processes, and basic data type management.
+*   `Data / Transformations` - Streamline data loading, transformation processes, and basic data type management.
 
-`Debugging` - Identify and resolve issues.
+*   `Debugging` - Identify and resolve issues.
 
-`Index / Table Optimizations` - Improve performance by targeting index use and creation, as well as database compaction and reorganization.
+*   `Index / Table Optimizations` - Improve performance by targeting index use and creation, as well as database compaction and reorganization.
 
-`Machine Learning` - Incorporate machine learning capabilities.
+*   `Machine Learning` - Incorporate machine learning capabilities.
 
-`Metrics` - Spotlight performance indicators, such as cache and tuple-level statistics, process information,  session-level activity, and more.
+*   `Metrics` - Spotlight performance indicators, such as cache and tuple-level statistics, process information,  session-level activity, and more.
 
-`Monitoring` - Offer real-time or near-real-time database activity and performance.
+*   `Monitoring` - Offer real-time or near-real-time database activity and performance.
 
-`Orchestration` - Establish ongoing database management related, but not limited to operations, deployment, or clusters.
+*   `Orchestration` - Establish ongoing database management related, but not limited to operations, deployment, or clusters.
 
-`Procedural Languages` - Enable efficient management, manipulation, and adaptation of database logic.
+*   `Procedural Languages` - Enable efficient management, manipulation, and adaptation of database logic.
 
-`Query Optimizations` - Augment query experiences surrounding metrics observability and usability.
+*   `Query Optimizations` - Augment query experiences surrounding metrics observability and usability.
 
-`Search` - Facilitate more efficient search operations within a database.
+*   `Search` - Facilitate more efficient search operations within a database.
 
-`Security` - Employ defense strategies for data and databases, including encryption, measures to prevent unauthorized access, and with other associated safeguarding tactics.
+*   `Security` - Employ defense strategies for data and databases, including encryption, measures to prevent unauthorized access, and with other associated safeguarding tactics.
 
-`Tooling / Admin` - Extend user management and database system oversight, as well as “under-the-hood” access to logic modification and external resources.
+*   `Tooling / Admin` - Extend user management and database system oversight, as well as “under-the-hood” access to logic modification and external resources.
 
 ## Development
+
+### Dependencies
+
+*   [rust](https://www.rust-lang.org/)
+*   [sqlx](https://crates.io/crates/sqlx-cli)
+*   [just](https://github.com/casey/just)
+
+``` sh
+brew install rustup-init just
+rustup update
+cargo install sqlx-cli
+```
+
 ### Getting Started
 
-1. Start postgres
-    ```
-    just start-postgres
+1.  Start postgres in Docker:
+
+    ``` sh
+    just run-postgres
     ```
 
-2. Set AWS environment variables
-    ```
+2.  Set AWS environment variables (not required for testing):
+
+    ``` sh
     export AWS_ACCESS_KEY_ID=<my-id>
     export AWS_SECRET_ACCESS_KEY=<my-key>
     export AWS_REGION=<my-region>
@@ -61,24 +76,35 @@ Extensions are grouped according to developer-centric use cases:
     export S3_BUCKET=<my-bucket>
     ```
 
-3. Initialize database (must install [sqlx](https://crates.io/crates/sqlx-cli))
-    ```
+3.  Initialize database with [sqlx](https://crates.io/crates/sqlx-cli):
+
+    ``` sh
     just run-migrations
     ```
 
-4. Run the registry code
+4.  Run the tests:
+
+    ``` sh
+    just test
     ```
+
+5.  Run the registry code
+
+    ``` sh
     just run
     ```
 
 ### Usage
+
 The registry will run at `http://localhost:8080` by default. The [Trunk CLI](../cli) can be configured to interact with
 a local registry by using the `--registry` flag. Example:
+
 ```shell
 TRUNK_API_TOKEN=<my-token> trunk publish --registry http://localhost:8080
 ```
 
 Routes can also be called with tools like `curl`. Examples:
+
 ```shell
 curl --request GET --url 'http://localhost:8080/extensions/all'
 ```
@@ -104,9 +130,11 @@ curl -F metadata='{\
 ```
 
 ## Architecture
+
 The Trunk registry is made up of the following components:
-- API
-- PostgreSQL database
-- AWS S3 bucket
+
+-   API
+-   PostgreSQL database
+-   AWS S3 bucket
 
 ![architecture.svg](../assets/architecture.svg)

--- a/registry/justfile
+++ b/registry/justfile
@@ -1,21 +1,26 @@
-DATABASE_URL := "postgresql://postgres:postgres@localhost:5432/postgres"
+export DATABASE_URL := env('DATABASE_URL', "postgresql://postgres:postgres@localhost:5432/postgres")
 
 format:
     cargo +nightly fmt --all
-    DATABASE_URL=${DATABASE_URL} cargo clippy
+    cargo clippy
     cargo sqlx prepare
 
 run-migrations:
-    DATABASE_URL={{DATABASE_URL}} cargo sqlx migrate run
+    cargo sqlx migrate run
 
 run-postgres:
     docker-compose kill || true
     docker rm --force trunk-registry-pg
     docker-compose up --build -d
 
+stop-postgres:
+    docker compose down
+
 run:
     RUST_LOG=debug \
-    DATABASE_URL={{DATABASE_URL}} \
     RUST_BACKTRACE=full \
     GITHUB_TOKEN=$(gh auth token) \
     cargo run
+
+test:
+    cargo test -- --nocapture

--- a/registry/tests/integration_test.rs
+++ b/registry/tests/integration_test.rs
@@ -89,7 +89,7 @@ mod tests {
         // Generate API token
         let req = test::TestRequest::post()
             .uri("/token/new")
-            .insert_header(("Authorization", dummy_jwt.clone()))
+            .insert_header(("Authorization", dummy_jwt))
             .to_request();
         let resp = test::call_service(&app, req).await;
         let token = test::read_body(resp).await;


### PR DESCRIPTION
Document the dependencies required to run them, and instructions to install them.

Teach the `justfile` to use the `DATABASE_URL` environment variable but to fall back on the original value if it's not set. Also export it for all of its targets, including the new `stop-postgres` and `test` targets.

Eliminate a warning from `registry/tests/integration_test.rs` for an unnecessary use of `clone()`.