### PR TITLE
Refactor CLI tests and get them passing on macOS

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.12.7"
+version = "0.12.8"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton", "Vinícius Miguel"]
 description = "A package manager for PostgreSQL extensions"
@@ -59,3 +59,4 @@ which = "4.4.0"
 assert_cmd = "2.0.8"
 git2 = "0.17.0"
 predicates = "2.1.5"
+tempfile = "3"

--- a/cli/README-DEV.md
+++ b/cli/README-DEV.md
@@ -1,0 +1,28 @@
+Trunk CLI Development
+=====================
+
+The Trunk CLI test suite requires:
+
+*   A local [Postgres] cluster, including development tools (specifically
+    [`pg_config`]) in the path.
+*   [Docker] to run containers that build extensions
+*   The `tar` utility (for now)
+*   Linux on `x86_64`; test will pass on ARM platforms like macOS, but many will
+    be skipped
+
+To run the tests:
+
+``` sh
+cargo test -- --nocapture --test-threads=4
+```
+
+The `--nocapture` option ensures all output prints to the terminal. The
+`--test-threads=4` limits the number of threads so as not to overwhelm Docker
+(seems especially prone with macOS Docker's VM).
+
+  [Postgres]: https://www.postgresql.org
+    "PostgreSQL: The World's Most Advanced Open Source Relational Database"
+  [`pg_config`]: https://www.postgresql.org/docs/current/app-pgconfig.html
+    "PostgreSQL Docs: pg_config"
+  [Docker]: https://www.docker.com
+    "Docker: Accelerated Container Application Development"

--- a/cli/src/commands/verify.rs
+++ b/cli/src/commands/verify.rs
@@ -53,10 +53,7 @@ async fn extract_sql_and_expected_files(
     github_project: GitHubProject<'_>,
 ) -> Result<ExtractedTestCases> {
     fn check_parent(expected_parent: &str, path: &Path) -> bool {
-        let Some(parent_obtained) = path
-            .parent()
-            .map(|parent| parent.components().last())
-            .flatten()
+        let Some(parent_obtained) = path.parent().and_then(|parent| parent.components().last())
         else {
             return false;
         };
@@ -167,7 +164,7 @@ impl SubCommand for VerifyCommand {
                 bail!("Found no matching SQL file for {:?}", expected_file);
             };
 
-            let obtained = run_psql(&sql_path, &self.connstring)?;
+            let obtained = run_psql(sql_path, &self.connstring)?;
             let obtained = obtained.lines().map(remove_psql_message);
             let expected = std::fs::read_to_string(expected_file)?;
 

--- a/cli/tests/.gitignore
+++ b/cli/tests/.gitignore
@@ -1,8 +1,2 @@
-pg_tle
-pg_tle/**
-postgres/**
-postgres*
 .trunk
 .trunk/**
-pgsql-http/**
-pgsql-http

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1,10 +1,10 @@
 use assert_cmd::prelude::*; // Add methods on commands
 use git2::Repository;
 use predicates::prelude::*; // Used for writing assertions
-use rand::Rng;
 use std::fs;
 use std::path::Path;
 use std::process::Command; // Run programs
+use tempfile::TempDir;
 
 const CARGO_BIN: &str = "trunk";
 
@@ -69,8 +69,10 @@ fn install_manifest_v1_extension() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn build_and_install_extension_with_directory_field() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = rand::thread_rng();
-    let output_dir = format!("/tmp/test_pgrx_{}", rng.gen_range(0..1000000));
+    // Set up a temporary directory that will be deleted when the test finishes.
+    let tmp_dir = TempDir::with_prefix("test_pljava_")?;
+    let output_dir = tmp_dir.path();
+    let tarball = &output_dir.join("pljava-1.6.5-pg15.tar.gz");
 
     // Construct a path relative to the current file's directory
     let mut extension_path = std::path::PathBuf::from(file!());
@@ -82,15 +84,22 @@ fn build_and_install_extension_with_directory_field() -> Result<(), Box<dyn std:
     cmd.arg("--path");
     cmd.arg(extension_path.as_os_str());
     cmd.arg("--output-path");
-    cmd.arg(&output_dir);
+    cmd.arg(output_dir);
     cmd.assert().code(0);
+
+    if !cfg!(target_arch = "x86_64") {
+        eprintln!(
+            "TODO: Trunk currently only supports the x86_64 architecture; skipping installation tests"
+        );
+        return Ok(());
+    }
 
     let mut cmd = Command::cargo_bin(CARGO_BIN)?;
     cmd.arg("install");
     cmd.arg("--pg-version");
     cmd.arg("15");
     cmd.arg("--file");
-    cmd.arg(Path::new(&output_dir).join("pljava-1.6.5-pg15.tar.gz"));
+    cmd.arg(tarball);
     cmd.arg("pljava");
     cmd.assert().code(0);
 
@@ -125,8 +134,11 @@ fn build_and_install_extension_with_directory_field() -> Result<(), Box<dyn std:
 
 #[test]
 fn build_pgrx_extension() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = rand::thread_rng();
-    let output_dir = format!("/tmp/test_pgrx_{}", rng.gen_range(0..1000000));
+    // Set up a temporary directory that will be deleted when the test finishes.
+    let tmp_dir = TempDir::with_prefix("test_pgrx_")?;
+    let output_dir = tmp_dir.path();
+    let tarball = &output_dir.join("test_pgrx_extension-0.0.0-pg15.tar.gz");
+    let manifest_file = &output_dir.join("manifest.json");
 
     // Construct a path relative to the current file's directory
     let mut extension_path = std::path::PathBuf::from(file!());
@@ -138,16 +150,13 @@ fn build_pgrx_extension() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--path");
     cmd.arg(extension_path.as_os_str());
     cmd.arg("--output-path");
-    cmd.arg(output_dir.clone());
+    cmd.arg(output_dir);
     cmd.assert().code(0);
-    assert!(std::path::Path::new(
-        format!("{output_dir}/test_pgrx_extension-0.0.0-pg15.tar.gz").as_str()
-    )
-    .exists());
+    assert!(output_dir.exists());
     // assert any license files are included
     let output = Command::new("tar")
         .arg("-tvf")
-        .arg(format!("{output_dir}/test_pgrx_extension-0.0.0-pg15.tar.gz").as_str())
+        .arg(tarball)
         .output()
         .expect("failed to run tar command");
     let stdout = String::from_utf8(output.stdout).unwrap();
@@ -156,18 +165,22 @@ fn build_pgrx_extension() -> Result<(), Box<dyn std::error::Error>> {
     // assert extension_name and loadable_libraries is in manifest.json
     let _extract = Command::new("tar")
         .arg("-xvf")
-        .arg(format!("{output_dir}/test_pgrx_extension-0.0.0-pg15.tar.gz").as_str())
+        .arg(tarball)
         .arg("-C")
-        .arg(format!("{output_dir}").as_str())
+        .arg(output_dir)
         .output()
         .expect("failed to run tar command");
 
-    let manifest = Command::new("cat")
-        .arg(format!("{output_dir}/manifest.json").as_str())
-        .output()
-        .expect("failed to run cat command");
-    let stdout = String::from_utf8(manifest.stdout).unwrap();
-    assert!(stdout.contains("\"extension_name\": \"test_pgrx_extension\""));
+    assert!(manifest_file.exists());
+    let manifest: String = fs::read_to_string(manifest_file)?;
+    assert!(manifest.contains("\"extension_name\": \"test_pgrx_extension\""));
+
+    if !cfg!(target_arch = "x86_64") {
+        eprintln!(
+            "TODO: Trunk currently only supports the x86_64 architecture; skipping installation tests"
+        );
+        return Ok(());
+    }
 
     // assert post installation steps contain correct CREATE EXTENSION command
     let mut cmd = Command::cargo_bin(CARGO_BIN)?;
@@ -175,23 +188,21 @@ fn build_pgrx_extension() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--pg-version");
     cmd.arg("15");
     cmd.arg("--file");
-    cmd.arg(format!("{output_dir}/test_pgrx_extension-0.0.0-pg15.tar.gz").as_str());
+    cmd.arg(tarball);
     cmd.arg("test_pgrx_extension");
     let output = cmd.output()?;
     let stdout = String::from_utf8(output.stdout)?;
     cmd.assert().code(0);
     assert!(stdout.contains("CREATE EXTENSION IF NOT EXISTS test_pgrx_extension CASCADE;"));
 
-    // delete the temporary file
-    std::fs::remove_dir_all(output_dir)?;
-
     Ok(())
 }
 
 #[test]
 fn build_pgrx_extension_bad_name() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = rand::thread_rng();
-    let output_dir = format!("/tmp/test_pgrx_{}", rng.gen_range(0..1000000));
+    // Set up a temporary directory that will be deleted when the test finishes.
+    let tmp_dir = TempDir::with_prefix("test_pgrx_bad_name_")?;
+    let output_dir = tmp_dir.path();
 
     // Construct a path relative to the current file's directory
     let mut extension_path = std::path::PathBuf::from(file!());
@@ -205,7 +216,7 @@ fn build_pgrx_extension_bad_name() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--name");
     cmd.arg("bad_name");
     cmd.arg("--output-path");
-    cmd.arg(output_dir.clone());
+    cmd.arg(output_dir);
     cmd.assert().code(1);
 
     Ok(())
@@ -213,8 +224,9 @@ fn build_pgrx_extension_bad_name() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn build_pgrx_extension_bad_version() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = rand::thread_rng();
-    let output_dir = format!("/tmp/test_pgrx_{}", rng.gen_range(0..1000000));
+    // Set up a temporary directory that will be deleted when the test finishes.
+    let tmp_dir = TempDir::with_prefix("test_pgrx_bad_version_")?;
+    let output_dir = tmp_dir.path();
 
     // Construct a path relative to the current file's directory
     let mut extension_path = std::path::PathBuf::from(file!());
@@ -228,7 +240,7 @@ fn build_pgrx_extension_bad_version() -> Result<(), Box<dyn std::error::Error>> 
     cmd.arg("--version");
     cmd.arg("0.0.1");
     cmd.arg("--output-path");
-    cmd.arg(output_dir.clone());
+    cmd.arg(output_dir);
     cmd.assert().code(1);
 
     Ok(())
@@ -236,19 +248,17 @@ fn build_pgrx_extension_bad_version() -> Result<(), Box<dyn std::error::Error>> 
 
 #[test]
 fn build_c_extension() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = rand::thread_rng();
-    let output_dir = format!("/tmp/pg_tle_test_{}", rng.gen_range(0..1000000));
+    // Set up a temporary directory that will be deleted when the test finishes.
+    let tmp_dir = TempDir::with_prefix("test_pg_tle_")?;
+    let output_dir = tmp_dir.path();
+    let tarball = &output_dir.join("pg_tle-1.0.3-pg15.tar.gz");
+    let manifest_file = &output_dir.join("manifest.json");
 
-    let current_file_path = Path::new(file!()).canonicalize().unwrap();
     // Example of a C extension
     let repo_url = "https://github.com/aws/pg_tle.git";
     // clone and checkout ref v1.0.3
-    let repo_dir_path = current_file_path.parent().unwrap().join("pg_tle");
-    let repo_dir = repo_dir_path;
-    if repo_dir.exists() {
-        fs::remove_dir_all(repo_dir.clone()).unwrap();
-    }
-    let repo = Repository::clone(repo_url, &repo_dir).unwrap();
+    let repo_dir = &output_dir.join("pg_tle");
+    let repo = Repository::clone(repo_url, repo_dir).unwrap();
     let refname = "v1.0.3";
     let (object, reference) = repo.revparse_ext(refname).expect("Object not found");
     repo.checkout_tree(&object, None)
@@ -261,29 +271,22 @@ fn build_c_extension() -> Result<(), Box<dyn std::error::Error>> {
     }
     .expect("Failed to set HEAD");
 
-    // Construct a path relative to the current file's directory
-    let mut extension_path = std::path::PathBuf::from(file!());
-    extension_path.pop(); // Remove the file name from the path
-    extension_path.push("pg_tle");
-
     let mut cmd = Command::cargo_bin(CARGO_BIN)?;
     cmd.arg("build");
     cmd.arg("--path");
-    cmd.arg(extension_path.as_os_str());
+    cmd.arg(repo_dir);
     cmd.arg("--output-path");
-    cmd.arg(output_dir.clone());
+    cmd.arg(output_dir);
     cmd.arg("--version");
     cmd.arg("1.0.3");
     cmd.arg("--name");
     cmd.arg("pg_tle");
     cmd.assert().code(0);
-    assert!(
-        std::path::Path::new(format!("{output_dir}/pg_tle-1.0.3-pg15.tar.gz").as_str()).exists()
-    );
+    assert!(output_dir.exists());
     // assert any license files are included
     let output = Command::new("tar")
         .arg("-tvf")
-        .arg(format!("{output_dir}/pg_tle-1.0.3-pg15.tar.gz").as_str())
+        .arg(tarball)
         .output()
         .expect("failed to run tar command");
     let stdout = String::from_utf8(output.stdout).unwrap();
@@ -293,40 +296,32 @@ fn build_c_extension() -> Result<(), Box<dyn std::error::Error>> {
     // assert extension_name is in manifest.json
     let _extract = Command::new("tar")
         .arg("-xvf")
-        .arg(format!("{output_dir}/pg_tle-1.0.3-pg15.tar.gz").as_str())
+        .arg(tarball)
         .arg("-C")
-        .arg(format!("{output_dir}").as_str())
+        .arg(output_dir)
         .output()
         .expect("failed to run tar command");
 
-    let manifest = Command::new("cat")
-        .arg(format!("{output_dir}/manifest.json").as_str())
-        .output()
-        .expect("failed to run cat command");
-    let stdout = String::from_utf8(manifest.stdout).unwrap();
-    assert!(stdout.contains("\"extension_name\": \"pg_tle\""));
-
-    // delete the temporary file
-    std::fs::remove_dir_all(output_dir)?;
+    assert!(manifest_file.exists());
+    let manifest: String = fs::read_to_string(manifest_file)?;
+    assert!(manifest.contains("\"extension_name\": \"pg_tle\""));
 
     Ok(())
 }
 
 #[test]
 fn build_extension_custom_dockerfile() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = rand::thread_rng();
-    let output_dir = format!("/tmp/pg_http_test_{}", rng.gen_range(0..1000000));
+    // Set up a temporary directory that will be deleted when the test finishes.
+    let tmp_dir = TempDir::with_prefix("test_pg_http_")?;
+    let output_dir = tmp_dir.path();
+    let tarball = &output_dir.join("pgsql_http-1.5.0-pg15.tar.gz");
+    let manifest_file = &output_dir.join("manifest.json");
 
-    let current_file_path = Path::new(file!()).canonicalize().unwrap();
     // Example of a C extension requires another build-time requirement
     let repo_url = "https://github.com/pramsey/pgsql-http.git";
     // clone and checkout ref v1.5.0
-    let repo_dir_path = current_file_path.parent().unwrap().join("pgsql-http");
-    let repo_dir = repo_dir_path;
-    if repo_dir.exists() {
-        fs::remove_dir_all(repo_dir.clone()).unwrap();
-    }
-    let repo = Repository::clone(repo_url, &repo_dir).unwrap();
+    let repo_dir = &output_dir.join("pgsql-http");
+    let repo = Repository::clone(repo_url, repo_dir).unwrap();
     let refname = "v1.5.0";
     let (object, reference) = repo.revparse_ext(refname).expect("Object not found");
     repo.checkout_tree(&object, None)
@@ -339,11 +334,6 @@ fn build_extension_custom_dockerfile() -> Result<(), Box<dyn std::error::Error>>
     }
     .expect("Failed to set HEAD");
 
-    // Construct a path relative to the current file's directory
-    let mut extension_path = std::path::PathBuf::from(file!());
-    extension_path.pop(); // Remove the file name from the path
-    extension_path.push("pgsql-http");
-
     let mut dockerfile_path = std::path::PathBuf::from(file!());
     dockerfile_path.pop(); // Remove the file name from the path
     dockerfile_path.push("test_builders");
@@ -352,9 +342,9 @@ fn build_extension_custom_dockerfile() -> Result<(), Box<dyn std::error::Error>>
     let mut cmd = Command::cargo_bin(CARGO_BIN)?;
     cmd.arg("build");
     cmd.arg("--path");
-    cmd.arg(extension_path.as_os_str());
+    cmd.arg(repo_dir);
     cmd.arg("--output-path");
-    cmd.arg(output_dir.clone());
+    cmd.arg(output_dir);
     cmd.arg("--dockerfile");
     cmd.arg(dockerfile_path.clone());
     cmd.arg("--version");
@@ -362,14 +352,11 @@ fn build_extension_custom_dockerfile() -> Result<(), Box<dyn std::error::Error>>
     cmd.arg("--name");
     cmd.arg("pgsql_http");
     cmd.assert().code(0);
-    assert!(
-        std::path::Path::new(format!("{output_dir}/pgsql_http-1.5.0-pg15.tar.gz").as_str())
-            .exists()
-    );
+    assert!(output_dir.exists());
     // assert any license files are included
     let output = Command::new("tar")
         .arg("-tvf")
-        .arg(format!("{output_dir}/pgsql_http-1.5.0-pg15.tar.gz").as_str())
+        .arg(tarball)
         .output()
         .expect("failed to run tar command");
     let stdout = String::from_utf8(output.stdout).unwrap();
@@ -378,20 +365,24 @@ fn build_extension_custom_dockerfile() -> Result<(), Box<dyn std::error::Error>>
     // assert extension_name is in manifest.json
     let _extract = Command::new("tar")
         .arg("-xvf")
-        .arg(format!("{output_dir}/pgsql_http-1.5.0-pg15.tar.gz").as_str())
+        .arg(tarball)
         .arg("-C")
-        .arg(format!("{output_dir}").as_str())
+        .arg(output_dir)
         .output()
         .expect("failed to run tar command");
 
-    let manifest = Command::new("cat")
-        .arg(format!("{output_dir}/manifest.json").as_str())
-        .output()
-        .expect("failed to run cat command");
-    let stdout = String::from_utf8(manifest.stdout).unwrap();
+    assert!(manifest_file.exists());
+    let manifest: String = fs::read_to_string(manifest_file)?;
     // Note - name and extension_name are different here
-    assert!(stdout.contains("\"name\": \"pgsql_http\""));
-    assert!(stdout.contains("\"extension_name\": \"http\""));
+    assert!(manifest.contains("\"name\": \"pgsql_http\""));
+    assert!(manifest.contains("\"extension_name\": \"http\""));
+
+    if !cfg!(target_arch = "x86_64") {
+        eprintln!(
+            "TODO: Trunk currently only supports the x86_64 architecture; skipping installation tests"
+        );
+        return Ok(());
+    }
 
     // assert post installation steps contain correct CREATE EXTENSION command
     let mut cmd = Command::cargo_bin(CARGO_BIN)?;
@@ -399,7 +390,7 @@ fn build_extension_custom_dockerfile() -> Result<(), Box<dyn std::error::Error>>
     cmd.arg("--pg-version");
     cmd.arg("15");
     cmd.arg("--file");
-    cmd.arg(format!("{output_dir}/pgsql_http-1.5.0-pg15.tar.gz").as_str());
+    cmd.arg(tarball);
     cmd.arg("pgsql_http");
     let output = cmd.output()?;
     let stdout = String::from_utf8(output.stdout)?;
@@ -407,34 +398,22 @@ fn build_extension_custom_dockerfile() -> Result<(), Box<dyn std::error::Error>>
     assert!(!stdout.contains("CREATE EXTENSION IF NOT EXISTS pgsql_http CASCADE;"));
     assert!(stdout.contains("CREATE EXTENSION IF NOT EXISTS http CASCADE;"));
 
-    // delete the temporary file
-    std::fs::remove_dir_all(output_dir)?;
-
     Ok(())
 }
 
 #[test]
 fn build_pg_stat_statements() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = rand::thread_rng();
-    let output_dir = format!("/tmp/pg_stat_statements_test_{}", rng.gen_range(0..1000000));
+    // Set up a temporary directory that will be deleted when the test finishes.
+    let tmp_dir = TempDir::with_prefix("test_pg_stat_statements_")?;
+    let output_dir = tmp_dir.path();
+    let tarball = &output_dir.join("pg_stat_statements-1.10-pg15.tar.gz");
+    let manifest_file = &output_dir.join("manifest.json");
 
-    let current_file_path = Path::new(file!()).canonicalize().unwrap();
     // Example of a C extension requires another build-time requirement
+    // clone and checkout postgres REL_15_3
     let repo_url = "https://github.com/postgres/postgres.git";
-    // clone and checkout ref v1.5.0
-    let repo_dir_path = current_file_path
-        .parent()
-        .unwrap()
-        .join("postgres_pg_stat_statements");
-    let repo_dir = repo_dir_path;
-    if repo_dir.exists() {
-        println!(
-            "Repo directory {:?} already exists. Deleting.",
-            repo_dir.to_str()
-        );
-        fs::remove_dir_all(repo_dir.clone())?;
-    }
-    let repo = Repository::clone(repo_url, &repo_dir).unwrap();
+    let repo_dir = &output_dir.join("postgres_pg_stat_statements");
+    let repo = Repository::clone(repo_url, repo_dir).unwrap();
     let refname = "REL_15_3";
     let (object, reference) = repo.revparse_ext(refname).expect("Object not found");
     repo.checkout_tree(&object, None)
@@ -447,11 +426,6 @@ fn build_pg_stat_statements() -> Result<(), Box<dyn std::error::Error>> {
     }
     .expect("Failed to set HEAD");
 
-    // Construct a path relative to the current file's directory
-    let mut extension_path = std::path::PathBuf::from(file!());
-    extension_path.pop(); // Remove the file name from the path
-    extension_path.push("postgres_pg_stat_statements");
-
     let mut dockerfile_path = std::path::PathBuf::from(file!());
     dockerfile_path.pop(); // Remove the file name from the path
     dockerfile_path.push("test_builders");
@@ -460,9 +434,9 @@ fn build_pg_stat_statements() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin(CARGO_BIN)?;
     cmd.arg("build");
     cmd.arg("--path");
-    cmd.arg(extension_path.as_os_str());
+    cmd.arg(repo_dir);
     cmd.arg("--output-path");
-    cmd.arg(output_dir.clone());
+    cmd.arg(output_dir);
     cmd.arg("--dockerfile");
     cmd.arg(dockerfile_path.clone());
     cmd.arg("--install-command");
@@ -472,14 +446,11 @@ fn build_pg_stat_statements() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--name");
     cmd.arg("pg_stat_statements");
     cmd.assert().code(0);
-    assert!(std::path::Path::new(
-        format!("{output_dir}/pg_stat_statements-1.10-pg15.tar.gz").as_str()
-    )
-    .exists());
+    assert!(output_dir.exists());
     // assert any license files are included
     let output = Command::new("tar")
         .arg("-tvf")
-        .arg(format!("{output_dir}/pg_stat_statements-1.10-pg15.tar.gz").as_str())
+        .arg(tarball)
         .output()
         .expect("failed to run tar command");
     let stdout = String::from_utf8(output.stdout).unwrap();
@@ -489,28 +460,26 @@ fn build_pg_stat_statements() -> Result<(), Box<dyn std::error::Error>> {
     // assert extension_name is in manifest.json
     let _extract = Command::new("tar")
         .arg("-xvf")
-        .arg(format!("{output_dir}/pg_stat_statements-1.10-pg15.tar.gz").as_str())
+        .arg(tarball)
         .arg("-C")
-        .arg(format!("{output_dir}").as_str())
+        .arg(output_dir)
         .output()
         .expect("failed to run tar command");
 
-    let manifest = Command::new("cat")
-        .arg(format!("{output_dir}/manifest.json").as_str())
-        .output()
-        .expect("failed to run cat command");
-    let stdout = String::from_utf8(manifest.stdout).unwrap();
-    assert!(stdout.contains("\"extension_name\": \"pg_stat_statements\""));
-    // delete the temporary file
-    std::fs::remove_dir_all(output_dir)?;
+    assert!(manifest_file.exists());
+    let manifest: String = fs::read_to_string(manifest_file)?;
+    assert!(manifest.contains("\"extension_name\": \"pg_stat_statements\""));
 
     Ok(())
 }
 
 #[test]
 fn build_pg_cron_trunk_toml() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = rand::thread_rng();
-    let output_dir = format!("/tmp/pg_cron_test_{}", rng.gen_range(0..1000000));
+    // Set up a temporary directory that will be deleted when the test finishes.
+    let tmp_dir = TempDir::with_prefix("test_pg_cron_trunk_toml_")?;
+    let output_dir = tmp_dir.path();
+    let tarball = &output_dir.join("pg_cron-1.5.2-pg15.tar.gz");
+    let manifest_file = &output_dir.join("manifest.json");
 
     // Construct a path relative to the current file's directory
     let mut trunkfile_path = std::path::PathBuf::from(file!());
@@ -523,15 +492,14 @@ fn build_pg_cron_trunk_toml() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--path");
     cmd.arg(trunkfile_path.as_os_str());
     cmd.arg("--output-path");
-    cmd.arg(output_dir.clone());
+    cmd.arg(output_dir);
     cmd.assert().code(0);
-    assert!(
-        std::path::Path::new(format!("{output_dir}/pg_cron-1.5.2-pg15.tar.gz").as_str()).exists()
-    );
+    assert!(tarball.exists());
+
     // assert any license files are included
     let output = Command::new("tar")
         .arg("-tvf")
-        .arg(format!("{output_dir}/pg_cron-1.5.2-pg15.tar.gz").as_str())
+        .arg(tarball)
         .output()
         .expect("failed to run tar command");
     let stdout = String::from_utf8(output.stdout).unwrap();
@@ -540,37 +508,43 @@ fn build_pg_cron_trunk_toml() -> Result<(), Box<dyn std::error::Error>> {
     // assert extension_name and loadable_libraries is in manifest.json
     let _extract = Command::new("tar")
         .arg("-xvf")
-        .arg(format!("{output_dir}/pg_cron-1.5.2-pg15.tar.gz").as_str())
+        .arg(tarball)
         .arg("-C")
-        .arg(format!("{output_dir}").as_str())
+        .arg(output_dir)
         .output()
         .expect("failed to run tar command");
 
-    let manifest = Command::new("cat")
-        .arg(format!("{output_dir}/manifest.json").as_str())
-        .output()
-        .expect("failed to run cat command");
-    let stdout = String::from_utf8(manifest.stdout).unwrap();
-    assert!(stdout.contains("\"extension_name\": \"extension_name_from_toml\""));
-    assert!(stdout.contains("\"loadable_libraries\": [\n    {\n      \"library_name\": \"shared_preload_libraries_from_toml\",\n      \"requires_restart\": true,\n      \"priority\": 1\n    },\n    {\n      \"library_name\": \"shared_preload_libraries_from_toml_2\",\n      \"requires_restart\": false,\n      \"priority\": 2\n    }\n  ]"));
+    assert!(manifest_file.exists());
+    let manifest = fs::read_to_string(manifest_file)?;
+    assert!(manifest.contains("\"extension_name\": \"extension_name_from_toml\""));
+    assert!(manifest.contains("\"loadable_libraries\": [\n    {\n      \"library_name\": \"shared_preload_libraries_from_toml\",\n      \"requires_restart\": true,\n      \"priority\": 1\n    },\n    {\n      \"library_name\": \"shared_preload_libraries_from_toml_2\",\n      \"requires_restart\": false,\n      \"priority\": 2\n    }\n  ]"));
     // Config name
-    assert!(stdout.contains("ip_address"));
+    assert!(manifest.contains("ip_address"));
     // Is required
-    assert!(stdout.contains("is_required\": true"));
+    assert!(manifest.contains("is_required\": true"));
     // Config name
-    assert!(stdout.contains("port"));
+    assert!(manifest.contains("port"));
     // Recommended default value
-    assert!(stdout.contains("8801"));
-    assert!(stdout.contains("\"dependencies\": {\n    \"apt\": [\n      \"libpq5\"\n    ],\n    \"dnf\": [\n      \"libpq-devel\"\n    ]\n  }") ||
-            stdout.contains("\"dependencies\": {\n    \"dnf\": [\n      \"libpq-devel\"\n    ],\n    \"apt\": [\n      \"libpq5\"\n    ]\n  }"));
+    assert!(manifest.contains("8801"));
+    assert!(manifest.contains("\"dependencies\": {\n    \"apt\": [\n      \"libpq5\"\n    ],\n    \"dnf\": [\n      \"libpq-devel\"\n    ]\n  }") ||
+            manifest.contains("\"dependencies\": {\n    \"dnf\": [\n      \"libpq-devel\"\n    ],\n    \"apt\": [\n      \"libpq5\"\n    ]\n  }"));
+
+    if !cfg!(target_arch = "x86_64") {
+        eprintln!(
+            "TODO: Trunk currently only supports the x86_64 architecture; skipping installation tests"
+        );
+        return Ok(());
+    }
+
     // assert post installation steps contain correct CREATE EXTENSION command
     let mut cmd = Command::cargo_bin(CARGO_BIN)?;
     cmd.arg("install");
     cmd.arg("--pg-version");
     cmd.arg("15");
     cmd.arg("--file");
-    cmd.arg(format!("{output_dir}/pg_cron-1.5.2-pg15.tar.gz").as_str());
+    cmd.arg(tarball);
     cmd.arg("pg_cron");
+
     let output = cmd.output()?;
     let stdout = String::from_utf8(output.stdout)?;
     cmd.assert().code(0);
@@ -584,27 +558,20 @@ fn build_pg_cron_trunk_toml() -> Result<(), Box<dyn std::error::Error>> {
     assert!(stdout.contains("shared_preload_libraries = 'shared_preload_libraries_from_toml, shared_preload_libraries_from_toml_2'"));
 
     // assert that the dependencies were written to manifest
-    let manifest = Command::new("cat")
-        .arg(format!("{output_dir}/manifest.json").as_str())
-        .output()
-        .expect("failed to run cat command");
-
-    let stdout = String::from_utf8(manifest.stdout).unwrap();
-    assert!(stdout.contains("\"extension_dependencies\": [\n    \"btree_gin\"\n  ],"));
-
-    // delete the temporary file
-    std::fs::remove_dir_all(output_dir)?;
+    assert!(manifest_file.exists());
+    let manifest: String = fs::read_to_string(manifest_file)?;
+    assert!(manifest.contains("\"extension_dependencies\": [\n    \"btree_gin\"\n  ],"));
 
     Ok(())
 }
 
 #[test]
 fn build_pgrx_with_trunk_toml() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = rand::thread_rng();
-    let output_dir = format!(
-        "/tmp/test_pgrx_with_trunk_toml_{}",
-        rng.gen_range(0..1000000)
-    );
+    // Set up a temporary directory that will be deleted when the test finishes.
+    let tmp_dir = TempDir::with_prefix("test_pgrx_trunk_toml_")?;
+    let output_dir = tmp_dir.path();
+    let tarball = &output_dir.join("test_pgrx_extension-0.0.0-pg15.tar.gz");
+    let manifest_file = &output_dir.join("manifest.json");
 
     // Construct a path relative to the current file's directory
     let mut trunkfile_path = std::path::PathBuf::from(file!());
@@ -617,16 +584,14 @@ fn build_pgrx_with_trunk_toml() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--path");
     cmd.arg(trunkfile_path.as_os_str());
     cmd.arg("--output-path");
-    cmd.arg(output_dir.clone());
+    cmd.arg(output_dir);
     cmd.assert().code(0);
-    assert!(std::path::Path::new(
-        format!("{output_dir}/test_pgrx_extension-0.0.0-pg15.tar.gz").as_str()
-    )
-    .exists());
+    assert!(tarball.exists());
+
     // assert any license files are included
     let output = Command::new("tar")
         .arg("-tvf")
-        .arg(format!("{output_dir}/test_pgrx_extension-0.0.0-pg15.tar.gz").as_str())
+        .arg(tarball)
         .output()
         .expect("failed to run tar command");
     let stdout = String::from_utf8(output.stdout).unwrap();
@@ -635,21 +600,18 @@ fn build_pgrx_with_trunk_toml() -> Result<(), Box<dyn std::error::Error>> {
     // assert extension_name and loadable_libraries is in manifest.json
     let _extract = Command::new("tar")
         .arg("-xvf")
-        .arg(format!("{output_dir}/test_pgrx_extension-0.0.0-pg15.tar.gz").as_str())
+        .arg(tarball)
         .arg("-C")
-        .arg(format!("{output_dir}").as_str())
+        .arg(output_dir)
         .output()
         .expect("failed to run tar command");
 
-    let manifest = Command::new("cat")
-        .arg(format!("{output_dir}/manifest.json").as_str())
-        .output()
-        .expect("failed to run cat command");
-    let stdout = String::from_utf8(manifest.stdout).unwrap();
-    assert!(stdout.contains("\"extension_name\": \"extension_name_from_toml\""));
-    assert!(stdout.contains("\"loadable_libraries\": [\n    {\n      \"library_name\": \"shared_preload_libraries_from_toml\",\n      \"requires_restart\": true,\n      \"priority\": 1\n    },\n    {\n      \"library_name\": \"another_shared_preload_library\",\n      \"requires_restart\": false,\n      \"priority\": 2\n    }\n  ]"));
-    assert!(stdout.contains("\"another_shared_preload_library\""));
-    assert!(stdout.contains("\"libpq5\""));
+    assert!(manifest_file.exists());
+    let manifest: String = fs::read_to_string(manifest_file)?;
+    assert!(manifest.contains("\"extension_name\": \"extension_name_from_toml\""));
+    assert!(manifest.contains("\"loadable_libraries\": [\n    {\n      \"library_name\": \"shared_preload_libraries_from_toml\",\n      \"requires_restart\": true,\n      \"priority\": 1\n    },\n    {\n      \"library_name\": \"another_shared_preload_library\",\n      \"requires_restart\": false,\n      \"priority\": 2\n    }\n  ]"));
+    assert!(manifest.contains("\"another_shared_preload_library\""));
+    assert!(manifest.contains("\"libpq5\""));
 
     // Get output of 'pg_config --pkglibdir'
     let output = Command::new("pg_config")
@@ -659,11 +621,15 @@ fn build_pgrx_with_trunk_toml() -> Result<(), Box<dyn std::error::Error>> {
     let pkglibdir = String::from_utf8(output.stdout)?;
     let pkglibdir = pkglibdir.trim();
 
+    if !cfg!(target_arch = "x86_64") {
+        eprintln!(
+            "TODO: Trunk currently only supports the x86_64 architecture; skipping installation tests"
+        );
+        return Ok(());
+    }
+
     // Remove .so if it exists
-    let _rm_so = Command::new("rm")
-        .arg(format!("{pkglibdir}/test_pgrx_extension.so").as_str())
-        .output()
-        .expect("failed to remove .so file");
+    std::fs::remove_file(format!("{pkglibdir}/test_pgrx_extension.so").as_str())?;
 
     // assert post installation steps contain correct CREATE EXTENSION command
     let mut cmd = Command::cargo_bin(CARGO_BIN)?;
@@ -671,7 +637,7 @@ fn build_pgrx_with_trunk_toml() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--pg-version");
     cmd.arg("15");
     cmd.arg("--file");
-    cmd.arg(format!("{output_dir}/test_pgrx_extension-0.0.0-pg15.tar.gz").as_str());
+    cmd.arg(tarball);
     cmd.arg("test_pgrx_extension");
     let output = cmd.output()?;
     let stdout = String::from_utf8(output.stdout)?;
@@ -684,19 +650,14 @@ fn build_pgrx_with_trunk_toml() -> Result<(), Box<dyn std::error::Error>> {
     assert!(stdout.contains("Add the following to your postgresql.conf:"));
     assert!(stdout.contains("shared_preload_libraries = 'shared_preload_libraries_from_toml, another_shared_preload_library'"));
 
-    // delete the temporary file
-    std::fs::remove_dir_all(output_dir)?;
-
     Ok(())
 }
 
 #[test]
 fn build_pgrx_with_trunk_toml_bad_name() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = rand::thread_rng();
-    let output_dir = format!(
-        "/tmp/test_pgrx_with_trunk_toml_bad_name_{}",
-        rng.gen_range(0..1000000)
-    );
+    // Set up a temporary directory that will be deleted when the test finishes.
+    let tmp_dir = TempDir::with_prefix("test_pgrx_with_trunk_toml_bad_name_")?;
+    let output_dir = tmp_dir.path();
 
     // Construct a path relative to the current file's directory
     let mut trunkfile_path = std::path::PathBuf::from(file!());
@@ -709,7 +670,7 @@ fn build_pgrx_with_trunk_toml_bad_name() -> Result<(), Box<dyn std::error::Error
     cmd.arg("--path");
     cmd.arg(trunkfile_path.as_os_str());
     cmd.arg("--output-path");
-    cmd.arg(output_dir.clone());
+    cmd.arg(output_dir);
     cmd.assert().code(1);
 
     Ok(())
@@ -717,11 +678,8 @@ fn build_pgrx_with_trunk_toml_bad_name() -> Result<(), Box<dyn std::error::Error
 
 #[test]
 fn build_pgrx_with_trunk_toml_bad_version() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = rand::thread_rng();
-    let output_dir = format!(
-        "/tmp/test_pgrx_with_trunk_toml_bad_version_{}",
-        rng.gen_range(0..1000000)
-    );
+    let tmp_dir = TempDir::with_prefix("test_pgrx_with_trunk_toml_bad_version_")?;
+    let output_dir = tmp_dir.path();
 
     // Construct a path relative to the current file's directory
     let mut trunkfile_path = std::path::PathBuf::from(file!());
@@ -734,7 +692,7 @@ fn build_pgrx_with_trunk_toml_bad_version() -> Result<(), Box<dyn std::error::Er
     cmd.arg("--path");
     cmd.arg(trunkfile_path.as_os_str());
     cmd.arg("--output-path");
-    cmd.arg(output_dir.clone());
+    cmd.arg(output_dir);
     cmd.assert().code(1);
 
     Ok(())
@@ -743,25 +701,16 @@ fn build_pgrx_with_trunk_toml_bad_version() -> Result<(), Box<dyn std::error::Er
 // Test for extension with no control file
 #[test]
 fn build_auto_explain() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = rand::thread_rng();
-    let output_dir = format!("/tmp/auto_explain_test_{}", rng.gen_range(0..1000000));
+    // Set up a temporary directory that will be deleted when the test finishes.
+    let tmp_dir = TempDir::with_prefix("test_auto_explain_")?;
+    let output_dir = tmp_dir.path();
+    let tarball = &output_dir.join("auto_explain-15.3.0-pg15.tar.gz");
+    let manifest_file = &output_dir.join("manifest.json");
 
-    let current_file_path = Path::new(file!()).canonicalize().unwrap();
     // Example of a C extension requires another build-time requirement
     let repo_url = "https://github.com/postgres/postgres.git";
-    let repo_dir_path = current_file_path
-        .parent()
-        .unwrap()
-        .join("postgres_auto_explain");
-    let repo_dir = repo_dir_path;
-    if repo_dir.exists() {
-        println!(
-            "Repo directory {:?} already exists. Deleting.",
-            repo_dir.to_str()
-        );
-        fs::remove_dir_all(repo_dir.clone())?;
-    }
-    let repo = Repository::clone(repo_url, &repo_dir).unwrap();
+    let repo_dir = &output_dir.join("postgres");
+    let repo = Repository::clone(repo_url, repo_dir).unwrap();
     let refname = "REL_15_3";
     let (object, reference) = repo.revparse_ext(refname).expect("Object not found");
     repo.checkout_tree(&object, None)
@@ -774,11 +723,6 @@ fn build_auto_explain() -> Result<(), Box<dyn std::error::Error>> {
     }
     .expect("Failed to set HEAD");
 
-    // Construct a path relative to the current file's directory
-    let mut extension_path = std::path::PathBuf::from(file!());
-    extension_path.pop(); // Remove the file name from the path
-    extension_path.push("postgres_auto_explain");
-
     let mut dockerfile_path = std::path::PathBuf::from(file!());
     dockerfile_path.pop(); // Remove the file name from the path
     dockerfile_path.push("test_builders");
@@ -787,9 +731,9 @@ fn build_auto_explain() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin(CARGO_BIN)?;
     cmd.arg("build");
     cmd.arg("--path");
-    cmd.arg(extension_path.as_os_str());
+    cmd.arg(repo_dir);
     cmd.arg("--output-path");
-    cmd.arg(output_dir.clone());
+    cmd.arg(output_dir);
     cmd.arg("--dockerfile");
     cmd.arg(dockerfile_path.clone());
     cmd.arg("--install-command");
@@ -799,14 +743,11 @@ fn build_auto_explain() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--name");
     cmd.arg("auto_explain");
     cmd.assert().code(0);
-    assert!(
-        std::path::Path::new(format!("{output_dir}/auto_explain-15.3.0-pg15.tar.gz").as_str())
-            .exists()
-    );
+    assert!(tarball.exists());
     // assert any license files are included
     let output = Command::new("tar")
         .arg("-tvf")
-        .arg(format!("{output_dir}/auto_explain-15.3.0-pg15.tar.gz").as_str())
+        .arg(tarball)
         .output()
         .expect("failed to run tar command");
     let stdout = String::from_utf8(output.stdout).unwrap();
@@ -816,40 +757,42 @@ fn build_auto_explain() -> Result<(), Box<dyn std::error::Error>> {
     // assert extension_name is in manifest.json
     let _extract = Command::new("tar")
         .arg("-xvf")
-        .arg(format!("{output_dir}/auto_explain-15.3.0-pg15.tar.gz").as_str())
+        .arg(tarball)
         .arg("-C")
-        .arg(format!("{output_dir}").as_str())
+        .arg(output_dir)
         .output()
         .expect("failed to run tar command");
 
-    let manifest = Command::new("cat")
-        .arg(format!("{output_dir}/manifest.json").as_str())
-        .output()
-        .expect("failed to run cat command");
-    let stdout = String::from_utf8(manifest.stdout).unwrap();
+    assert!(manifest_file.exists());
+    let manifest: String = fs::read_to_string(manifest_file)?;
+    assert!(manifest.contains("\"extension_name\": \"auto_explain\""));
 
-    assert!(stdout.contains("\"extension_name\": \"auto_explain\""));
+    if !cfg!(target_arch = "x86_64") {
+        eprintln!(
+            "TODO: Trunk currently only supports the x86_64 architecture; skipping installation tests"
+        );
+        return Ok(());
+    }
 
     let mut cmd = Command::cargo_bin(CARGO_BIN)?;
     cmd.arg("install");
     cmd.arg("--pg-version");
     cmd.arg("15");
     cmd.arg("--file");
-    cmd.arg(format!("{output_dir}/auto_explain-15.3.0-pg15.tar.gz").as_str());
+    cmd.arg(tarball);
     cmd.arg("auto_explain");
 
     cmd.assert().code(0);
-    // delete the temporary file
-    std::fs::remove_dir_all(output_dir)?;
 
     Ok(())
 }
 
 #[test]
 fn build_pg_unit() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = rand::thread_rng();
-    let output_dir = format!("/tmp/postgresql_unit_test_{}", rng.gen_range(0..1000000));
-    let package_name = "postgresql_unit-7.0.0-pg15.tar.gz";
+    // Set up a temporary directory that will be deleted when the test finishes.
+    let tmp_dir = TempDir::with_prefix("test_pg_unit_")?;
+    let output_dir = tmp_dir.path();
+    let tarball = &output_dir.join("postgresql_unit-7.0.0-pg15.tar.gz");
 
     // Construct a path relative to the current file's directory
     let mut extension_path = std::path::PathBuf::from(file!());
@@ -861,25 +804,19 @@ fn build_pg_unit() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--path");
     cmd.arg(extension_path.as_os_str());
     cmd.arg("--output-path");
-    cmd.arg(&output_dir);
+    cmd.arg(output_dir);
     cmd.assert().code(0);
-
-    let package_location = format!("{output_dir}/{package_name}");
-
-    assert!(file_exists(&package_location));
+    assert!(tarball.exists());
 
     // assert any license files are included
     let output = Command::new("tar")
         .arg("-tvf")
-        .arg(package_location)
+        .arg(tarball)
         .output()
         .expect("failed to run tar command");
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("extension/unit_prefixes.data"));
     assert!(stdout.contains("extension/unit_units.data"));
-
-    // delete the temporary file
-    std::fs::remove_dir_all(output_dir)?;
 
     Ok(())
 }
@@ -887,8 +824,10 @@ fn build_pg_unit() -> Result<(), Box<dyn std::error::Error>> {
 // Build and install postgis
 #[test]
 fn build_install_postgis() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = rand::thread_rng();
-    let output_dir = format!("/tmp/postgis_test_{}", rng.gen_range(0..1000000));
+    // Set up a temporary directory that will be deleted when the test finishes.
+    let tmp_dir = TempDir::with_prefix("test_postgis_")?;
+    let output_dir = tmp_dir.path();
+    let tarball = &output_dir.join("postgis-3.4.0-pg15.tar.gz");
 
     // Construct a path relative to the current file's directory
     let mut trunkfile_path = std::path::PathBuf::from(file!());
@@ -901,11 +840,16 @@ fn build_install_postgis() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--path");
     cmd.arg(trunkfile_path.as_os_str());
     cmd.arg("--output-path");
-    cmd.arg(output_dir.clone());
+    cmd.arg(output_dir);
     cmd.assert().code(0);
-    assert!(file_exists(format!(
-        "{output_dir}/postgis-3.4.0-pg15.tar.gz"
-    )));
+    assert!(output_dir.exists());
+
+    if !cfg!(target_arch = "x86_64") {
+        eprintln!(
+            "TODO: Trunk currently only supports the x86_64 architecture; skipping installation tests"
+        );
+        return Ok(());
+    }
 
     // Get output of 'pg_config --sharedir'
     let output = Command::new("pg_config")
@@ -928,7 +872,7 @@ fn build_install_postgis() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--pg-version");
     cmd.arg("15");
     cmd.arg("--file");
-    cmd.arg(format!("{output_dir}/postgis-3.4.0-pg15.tar.gz").as_str());
+    cmd.arg(tarball);
     cmd.arg("postgis");
     let output = cmd.output()?;
     let stderr = String::from_utf8(output.stderr)?;
@@ -940,9 +884,6 @@ fn build_install_postgis() -> Result<(), Box<dyn std::error::Error>> {
         "{sharedir}/extension/fuzzystrmatch.control"
     )));
     assert!(file_exists(format!("{sharedir}/extension/postgis.control")));
-
-    // delete the temporary file
-    std::fs::remove_dir_all(output_dir)?;
 
     Ok(())
 }

--- a/cli/tests/test_trunk_toml_dirs/postgis/Dockerfile
+++ b/cli/tests/test_trunk_toml_dirs/postgis/Dockerfile
@@ -23,4 +23,4 @@ RUN wget https://download.osgeo.org/postgis/source/postgis-3.4.0.tar.gz && \
 	tar xvf postgis-3.4.0.tar.gz && \
 	cd postgis-3.4.0 && \
 	./configure && \
-	make -j$(nproc)
+	make


### PR DESCRIPTION
To get the tests passing, add conditionals require the `x86_64` architecture to test `trunk install`, and to skip them on other architectures. This allows the individual tests to pass on macOS on Apple Silicon.

Add `README-DEV.md` to describe the dependencies required to run the CLI tests, as well as an instruction to limit the number of concurrent threads so as not to crush Docker (which happened regularly with macOS Docker's default configuration).

Refactor the tests for better file handling, including:

*   Use the tempfile::TempDir crate to create working directories automatically deleted when a test function finishes
*   Use Path objects instead of formatting strings for output directories, tarballs, and manifest files.
*   Move cloned Git repositories to the self-deleting temp directories rather than the repository itself.
*   Use fs::read_to_string instead of `cat` to read in files

Also: remove the `-j` option to `make` in the PostGIS test Dockerfile (`cli/tests/test_trunk_toml_dirs/postgis/Dockerfile`) to avoid [concurrency errors] that break the build, and remove a couple of warnings reported by `clippy`.

  [concurrency errors]: https://stat.ethz.ch/pipermail/r-devel/2022-May/081724.html