### PR TITLE
Add proper Postgres install to PATH

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.12.8"
+version = "0.12.9"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton", "Vinícius Miguel"]
 description = "A package manager for PostgreSQL extensions"

--- a/cli/images/c-builder/Dockerfile
+++ b/cli/images/c-builder/Dockerfile
@@ -16,5 +16,7 @@ RUN apt-get update && \
       pkg-config libssl-dev build-essential libclang-dev clang && \
     rm -rf /var/lib/apt/lists/*
 
+# Set the path to the version-specific Postgres install.
+ENV PATH="/usr/lib/postgresql/${PG_VERSION}/bin:${PATH}"
 USER postgres
 WORKDIR /app


### PR DESCRIPTION
In the c-builder image. Without this, it can default to using the core Debian postgres and, e.g., `/usr/bin/pg_config` is not what we want.