### PR TITLE
Use apt.postgresql.org.sh to install Postgres

### DIFF
--- a/cli/images/c-builder/Dockerfile
+++ b/cli/images/c-builder/Dockerfile
@@ -1,22 +1,22 @@
 ARG UBUNTU_VERSION=22.04
 FROM quay.io/coredb/ubuntu:${UBUNTU_VERSION}
 
+ADD https://salsa.debian.org/postgresql/postgresql-common/-/raw/master/pgdg/apt.postgresql.org.sh ./
+
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 ARG PG_VERSION=15
 
-RUN apt-get update && \
-    apt-get install -y \
-      curl unzip gpg wget git software-properties-common flex \
-    && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg > /dev/null \
-    && echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
-    && apt-get update  \
+RUN apt-get update \
     && apt-get install -y \
-      postgresql-${PG_VERSION} postgresql-server-dev-${PG_VERSION} \
-      pkg-config libssl-dev build-essential libclang-dev clang && \
-    rm -rf /var/lib/apt/lists/*
+      build-essential clang llvm llvm-dev llvm-runtime \
+      ca-certificates zip curl wget git software-properties-common flex \
+      libicu-dev libxml2 locales ssl-cert \
+      pkg-config libssl-dev libclang-dev \
+    && apt-get -y purge postgresql-client-common \
+    && chmod +x apt.postgresql.org.sh \
+    && ./apt.postgresql.org.sh -i -v ${PG_VERSION} \
+    && rm -rf apt.postgresql.org.sh /var/cache/apt/* /var/lib/apt/lists/*
 
-# Set the path to the version-specific Postgres install.
-ENV PATH="/usr/lib/postgresql/${PG_VERSION}/bin:${PATH}"
 USER postgres
 WORKDIR /app


### PR DESCRIPTION
Borrowed from the [pgxn-tools `Dockerfile`], developed under the guidance of Postgres apt maintainer Christoph Berg. Importantly, purge `postgresql-client-common` before installing the pgdb Postgres, since it conflicts with the pgdb package. This also allows the PATH configuration to be removed, as the `/usr/bin` Postgres commands are owned by pgdb.

  [pgxn-tools `Dockerfile`]: https://github.com/pgxn/docker-pgxn-tools/blob/main/Dockerfile