### PR TITLE
Refactor `pg_config` calls and test pgrx.so

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.12.10"
+version = "0.12.11"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton", "Vinícius Miguel"]
 description = "A package manager for PostgreSQL extensions"

--- a/cli/README-DEV.md
+++ b/cli/README-DEV.md
@@ -7,8 +7,8 @@ The Trunk CLI test suite requires:
     [`pg_config`]) in the path.
 *   [Docker] to run containers that build extensions
 *   The `tar` utility (for now)
-*   Linux on `x86_64`; test will pass on ARM platforms like macOS, but many will
-    be skipped
+*   Linux on `x86_64`; tests will pass on ARM platforms like macOS, but many
+    will be skipped
 
 To run the tests:
 


### PR DESCRIPTION
Add `pg_config_path()`,  which handles calls to `pg_config`, parses the output, and converts it to a PathBuf. Then use it consistently for config directory locations, and use the `join()` method on the resulting PathBuf structs to test various file locations, rather than use `format!()`.

Then add tests for the installation of the `test_pgrx_extension.so` and `pgrx_with_trunk_toml.so` files, to prove that `build_pgrx_extension()` and `build_pgrx_with_trunk_toml()` give it different names, and therefore the two tests won't stomp on each other (as was fixed in pull request #604).

Thanks @sjmiller609 for help writing `pg_config_path()`!