### PR TITLE
Refactor extension build command handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ temp.sh
 **/.DS_Store
 poetry.lock
 site/
+.vscode/

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.12.11"
+version = "0.12.12"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton", "Vinícius Miguel"]
 description = "A package manager for PostgreSQL extensions"

--- a/cli/src/commands/generic_build.rs
+++ b/cli/src/commands/generic_build.rs
@@ -13,7 +13,7 @@ use tokio::sync::mpsc;
 use tokio_task_manager::Task;
 
 use crate::commands::containers::{
-    build_image, exec_in_container, exec_in_container_with_exit_code, file_exists, locate_makefile,
+    build_image, exec_in_container, exec_in_container_with_exit_code, locate_makefile,
     makefile_contains_target, package_installed_extension_files, run_temporary_container,
     start_postgres,
 };
@@ -121,7 +121,7 @@ pub async fn build_generic(
 
     println!("Determining installation files...");
     let _exec_output =
-        exec_in_container(&docker, &temp_container.id, install_command, None).await?;
+        exec_in_container(&docker, &temp_container.id, install_command, None, None).await?;
 
     // Search for license files to include
     println!("Determining license files to include...");
@@ -132,6 +132,7 @@ pub async fn build_generic(
         &docker,
         &temp_container.id,
         vec!["mkdir", "/usr/licenses/"],
+        None,
         None,
     )
     .await?;
@@ -191,40 +192,14 @@ async fn run_tests(
         println!("make check was found in the Makefile");
         start_postgres(docker, container_id).await?;
 
-        let configure_file = project_dir.join("configure");
-        let configure_file = configure_file.to_str().unwrap();
-
-        let configure_exists = file_exists(docker, container_id, configure_file).await;
-        let exit_code = if configure_exists {
-            let (_, exit_code) = exec_in_container_with_exit_code(
-                docker,
-                container_id,
-                vec![
-                    "su",
-                    "postgres",
-                    "-c",                    
-                    &format!("bash -c \"./{configure_file} && make -C {project_dir_utf8} check && echo done\"")
-                ],
-                None,
-            )
-            .await?;
-
-            exit_code
-        } else {
-            let (_, exit_code) = exec_in_container_with_exit_code(
-                docker,
-                container_id,
-                vec![
-                    "su",
-                    "postgres",
-                    "-c",
-                    &format!("make -C {project_dir_utf8} check"),
-                ],
-                None,
-            )
-            .await?;
-            exit_code
-        };
+        let (_, exit_code) = exec_in_container_with_exit_code(
+            docker,
+            container_id,
+            vec!["make", "check"],
+            Some(project_dir_utf8),
+            Some(vec!["PGUSER=postgres"]),
+        )
+        .await?;
 
         anyhow::ensure!(matches!(exit_code, Some(0)), "Tests failed!");
 
@@ -239,20 +214,17 @@ async fn run_tests(
         exec_in_container(
             docker,
             container_id,
-            vec!["make", "-C", project_dir_utf8, "install"],
+            vec!["make", "install"],
+            Some(project_dir_utf8),
             None,
         )
         .await?;
         let (_output, exit_code) = exec_in_container_with_exit_code(
             docker,
             container_id,
-            vec![
-                "su",
-                "postgres",
-                "-c",
-                &format!("make -C {project_dir_utf8} installcheck"),
-            ],
-            None,
+            vec!["make", "installcheck"],
+            Some(project_dir_utf8),
+            Some(vec!["PGUSER=postgres"]),
         )
         .await?;
 

--- a/cli/src/commands/license.rs
+++ b/cli/src/commands/license.rs
@@ -104,6 +104,7 @@ pub async fn find_licenses(docker: Docker, container_id: &str) -> Result<Vec<Str
             "licen[cs]e.*",
         ],
         None,
+        None,
     )
     .await?;
     let lines = license_output.lines();
@@ -131,6 +132,7 @@ pub async fn copy_licenses(
                 license.to_string().as_str(),
                 "/usr/licenses/",
             ],
+            None,
             env.clone(),
         )
         .await?;

--- a/cli/src/commands/pgrx.rs
+++ b/cli/src/commands/pgrx.rs
@@ -198,6 +198,7 @@ pub async fn build_pgrx(
             "/",
         ],
         None,
+        None,
     )
     .await?;
 
@@ -210,6 +211,7 @@ pub async fn build_pgrx(
         &docker,
         &temp_container.id,
         vec!["mkdir", "/usr/licenses/"],
+        None,
         None,
     )
     .await?;


### PR DESCRIPTION
The contrib `Dockerfile`s run `./configure && make`, so not only is there no need to do so here, but it was causing issues by running the commands in the parent directory of the unpacked extension directory:

```
Executing in container: "su postgres -c bash -c \"././postgis-3.4.0/configure && make -C ./postgis-3.4.0 check && echo done\""
configure: error: source directory already configured; run "make distclean" there first
```

Apparently `./configure` won't re-run from a different directory unless `make distclean` is run. But it's not even necessary! So remove the check for the `configure` file in `run_tests()`, and then also remove the `file_exists()` function, as it's no longer uses.

Then refactor `exec_in_container()` and
`exec_in_container_with_exit_code()` to take a directory argument, and pass it to bollard's `CreateExecOptions()`, then pass the unpacked directory name in the appropriate places.

That includes especially `make check` and `make installcheck`. Also modify them so they no longe run as the `postgres` user --- which can cause permission issues, as the source is unpacked and owned by root in the `Dockerfile`s --- and instead set the `PGUSER` environment variable. This ensure that all tests are run as the `root` system user but connect to the `postgres` database as the `postgres` user.