### PR TITLE
Simplify the PostGIS `Dockerfile`

### DIFF
--- a/.github/workflows/trunk-install-test.yml
+++ b/.github/workflows/trunk-install-test.yml
@@ -18,7 +18,7 @@ jobs:
       - dind
       - large-8x8
     container:
-      image: quay.io/tembo/trunk-test-tembo:0.0.27
+      image: quay.io/tembo/trunk-test-tembo:0.0.31
       options: --user root
     env:
       PGHOST: "localhost"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.12.12"
+version = "0.12.13"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton", "Vinícius Miguel"]
 description = "A package manager for PostgreSQL extensions"

--- a/contrib/postgis/Dockerfile
+++ b/contrib/postgis/Dockerfile
@@ -2,26 +2,15 @@ ARG PG_VERSION=15
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 USER root
 
-RUN apt-get update && apt-get install -y \
- build-essential \
- libreadline-dev \
- zlib1g-dev \
- flex \
- bison \
- libxml2-dev \
- libxslt-dev \
- libssl-dev \
- libxml2-utils \
- xsltproc \
- ccache \
- libgdal-dev \
- libgeos-dev \
- osm2pgsql \
- libprotobuf-c-dev \
- protobuf-c-compiler
-
-RUN wget https://download.osgeo.org/postgis/source/postgis-3.4.0.tar.gz && \
-	tar xvf postgis-3.4.0.tar.gz && \
-	cd postgis-3.4.0 && \
-	./configure && \
-	make -j$(nproc)
+RUN apt-get update \
+	&& apt-get install -y \
+		libgeos-dev \
+		libproj-dev \
+		libprotobuf-c-dev \
+		protobuf-c-compiler \
+		libgdal-dev \
+	&& wget https://download.osgeo.org/postgis/source/postgis-3.4.0.tar.gz \
+	&& tar xvf postgis-3.4.0.tar.gz \
+	&& cd postgis-3.4.0 \
+	&& ./configure \
+	&& make


### PR DESCRIPTION
Remove redundant apt packages from the call to `apt-get` in the PostGIS `Dockerfile`, and keep it to a single `RUN` to limit the layer count.