### PR TITLE
Trigger `argm` publish

### DIFF
--- a/contrib/argm/Trunk.toml
+++ b/contrib/argm/Trunk.toml
@@ -7,6 +7,7 @@ description = "Argm postgresql extension: argmax/argmin and anyold aggregate fun
 documentation = "https://github.com/bashtanov/argm"
 categories = ["query_optimizations"]
 
+
 [dependencies]
 apt = ["libc6"]
 


### PR DESCRIPTION
This project is missing at https://registry.pgtrunk.io/api/v1/trunk-projects. Trigger publish to update missing trunk project metadata.