### PR TITLE
Trigger `hypopg` publish

### DIFF
--- a/contrib/hypopg/Trunk.toml
+++ b/contrib/hypopg/Trunk.toml
@@ -7,6 +7,7 @@ description = "Hypothetical Indexes for PostgreSQL."
 documentation = "https://hypopg.readthedocs.io/"
 categories = ["index_table_optimizations"]
 
+
 [dependencies]
 apt = ["libc6"]
 


### PR DESCRIPTION
This project is missing at https://registry.pgtrunk.io/api/v1/trunk-projects. Trigger publish to update missing trunk project metadata.