### PR TITLE
Trigger `fuzzystrmatch` publish

### DIFF
--- a/contrib/fuzzystrmatch/Trunk.toml
+++ b/contrib/fuzzystrmatch/Trunk.toml
@@ -8,6 +8,7 @@ homepage = "https://www.postgresql.org"
 documentation = "https://www.postgresql.org/docs/current/fuzzystrmatch.html"
 categories = ["search"]
 
+
 [dependencies]
 apt = ["libc6"]
 


### PR DESCRIPTION
This project is missing at https://registry.pgtrunk.io/api/v1/trunk-projects. Trigger publish to update missing trunk project metadata.