### PR TITLE
Trigger `pg_embedding` publish

### DIFF
--- a/contrib/pg_embedding/Trunk.toml
+++ b/contrib/pg_embedding/Trunk.toml
@@ -8,6 +8,7 @@ homepage = "https://neon.tech/"
 documentation = "https://github.com/neondatabase/pg_embedding"
 categories = ["machine_learning"]
 
+
 [dependencies]
 apt = ["libc6", "libgcc-s1", "libstdc++6"]
 


### PR DESCRIPTION
This project is missing at https://registry.pgtrunk.io/api/v1/trunk-projects. Trigger publish to update missing trunk project metadata.