### PR TITLE
Trigger `pg_mon` publish

### DIFF
--- a/contrib/pg_mon/Trunk.toml
+++ b/contrib/pg_mon/Trunk.toml
@@ -7,6 +7,7 @@ description = "PostgreSQL extension to enhance query monitoring."
 documentation = "https://github.com/RafiaSabih/pg_mon"
 categories = ["query_optimizations"]
 
+
 [dependencies]
 apt = ["libc6"]
 


### PR DESCRIPTION
This project is missing at https://registry.pgtrunk.io/api/v1/trunk-projects. Trigger publish to update missing trunk project metadata.