### PR TITLE
Trigger `pg_dirtyread` publish

### DIFF
--- a/contrib/pg_dirtyread/Trunk.toml
+++ b/contrib/pg_dirtyread/Trunk.toml
@@ -7,6 +7,7 @@ description = "Read dead but unvacuumed tuples from a PostgreSQL relation."
 documentation = "https://github.com/df7cb/pg_dirtyread"
 categories = ["search"]
 
+
 [dependencies]
 apt = ["libc6"]
 


### PR DESCRIPTION
This project is missing at https://registry.pgtrunk.io/api/v1/trunk-projects. Trigger publish to update missing trunk project metadata.