### PR TITLE
Bump `pg_cron` to 1.6.2

### DIFF
--- a/contrib/pg_cron/Dockerfile
+++ b/contrib/pg_cron/Dockerfile
@@ -1,6 +1,6 @@
 ARG PG_VERSION=15
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-ARG RELEASE=v1.5.2
+ARG RELEASE=v1.6.2
 
 # Clone repository
 RUN git clone https://github.com/citusdata/pg_cron.git

--- a/contrib/pg_cron/Trunk.toml
+++ b/contrib/pg_cron/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_cron"
-version = "1.5.0"
+version = "1.6.2"
 repository = "https://github.com/citusdata/pg_cron"
 license = "PostgreSQL"
 description = "Job scheduler for PostgreSQL."

--- a/contrib/pg_cron/Trunk.toml
+++ b/contrib/pg_cron/Trunk.toml
@@ -6,7 +6,7 @@ license = "PostgreSQL"
 description = "Job scheduler for PostgreSQL."
 homepage = "https://www.citusdata.com/"
 categories = ["orchestration"]
-preload_libraries = ["pg_cron"]
+loadable_libraries = [{ library_name = "pg_cron", requires_restart = true }]
 
 [dependencies]
 apt = ["libpq5", "libc6"]


### PR DESCRIPTION
This project is missing at https://registry.pgtrunk.io/api/v1/trunk-projects. Trigger publish to update missing trunk project metadata. Also bump to latest version.