### PR TITLE
Trigger `pg_buffercache` publish

### DIFF
--- a/contrib/pg_buffercache/Trunk.toml
+++ b/contrib/pg_buffercache/Trunk.toml
@@ -8,6 +8,7 @@ homepage = "https://www.postgresql.org"
 documentation = "https://www.postgresql.org/docs/current/pgbuffercache.html"
 categories = ["metrics"]
 
+
 [dependencies]
 apt = ["libc6"]
 


### PR DESCRIPTION
This project is missing at https://registry.pgtrunk.io/api/v1/trunk-projects. Trigger publish to update missing trunk project metadata.