### PR TITLE
Trigger `credcheck` publish

### DIFF
--- a/contrib/credcheck/Trunk.toml
+++ b/contrib/credcheck/Trunk.toml
@@ -7,7 +7,7 @@ description = "PostgreSQL plain credential checker"
 homepage = "https://www.migops.com/"
 documentation = "https://github.com/MigOpsRepos/credcheck"
 categories = ["tooling_admin"]
-preload_libraries = ["credcheck"]
+loadable_libraries = [{ library_name = "credcheck", requires_restart = true }]
 
 [dependencies]
 apt = ["libc6"]


### PR DESCRIPTION
This project is missing at https://registry.pgtrunk.io/api/v1/trunk-projects. Trigger publish to update missing trunk project metadata.