### PR TITLE
Trigger `pg_graphql` publish

### DIFF
--- a/contrib/pg_graphql/Dockerfile
+++ b/contrib/pg_graphql/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 # Set default Rust version
-RUN /root/.cargo/bin/rustup default stable && /root/.cargo/bin/rustup override set 1.72.0
+RUN /root/.cargo/bin/rustup default stable && /root/.cargo/bin/rustup override set 1.75.0
 
 RUN git clone https://github.com/supabase/pg_graphql.git
 

--- a/contrib/pg_graphql/Dockerfile
+++ b/contrib/pg_graphql/Dockerfile
@@ -1,7 +1,7 @@
 ARG PG_VERSION=15
 ARG RELEASE=v1.4.1
 
-FROM quay.io/coredb/pgrx-builder:pg${PG_VERSION}-pgrx0.10.0
+FROM quay.io/coredb/pgrx-builder:pg${PG_VERSION}-pgrx0.11.2
 USER root
 
 # extension build dependencies

--- a/contrib/pg_graphql/Trunk.toml
+++ b/contrib/pg_graphql/Trunk.toml
@@ -8,7 +8,6 @@ homepage = "https://supabase.com"
 documentation = "https://supabase.github.io/pg_graphql"
 categories = ["data_transformations"]
 
-
 [build]
 postgres_version = "15"
 platform = "linux/amd64"

--- a/contrib/pg_graphql/Trunk.toml
+++ b/contrib/pg_graphql/Trunk.toml
@@ -8,6 +8,7 @@ homepage = "https://supabase.com"
 documentation = "https://supabase.github.io/pg_graphql"
 categories = ["data_transformations"]
 
+
 [build]
 postgres_version = "15"
 platform = "linux/amd64"


### PR DESCRIPTION
This project is missing at https://registry.pgtrunk.io/api/v1/trunk-projects. Trigger publish to update missing trunk project metadata.