### PR TITLE
Trigger `hydra_columnar` publish

### DIFF
--- a/contrib/hydra_columnar/Trunk.toml
+++ b/contrib/hydra_columnar/Trunk.toml
@@ -8,6 +8,7 @@ homepage = "https://www.hydra.so"
 documentation = "https://github.com/hydradatabase/hydra"
 categories = ["analytics"]
 
+
 [dependencies]
 apt = ["libc6", "libzstd1", "liblz4-1"]
 


### PR DESCRIPTION
This project is missing at https://registry.pgtrunk.io/api/v1/trunk-projects. Trigger publish to update missing trunk project metadata.