### PR TITLE
Trigger `sslinfo` publish

### DIFF
--- a/contrib/sslinfo/Trunk.toml
+++ b/contrib/sslinfo/Trunk.toml
@@ -8,6 +8,7 @@ homepage = "https://www.postgresql.org"
 documentation = "https://www.postgresql.org/docs/current/sslinfo.html"
 categories = ["security"]
 
+
 [dependencies]
 apt = ["libc6", "openssl"]
 


### PR DESCRIPTION
This project is missing at https://registry.pgtrunk.io/api/v1/trunk-projects. Trigger publish to update missing trunk project metadata.