### PR TITLE
Bump `argm` to 1.1.2

### DIFF
--- a/contrib/argm/Dockerfile
+++ b/contrib/argm/Dockerfile
@@ -5,11 +5,5 @@ FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 # Clone repository
 RUN git clone https://github.com/bashtanov/argm.git
 
-# Set project version
-ARG RELEASE=1.1.1
-
 # Build extension
-RUN cd argm && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+RUN cd argm && make

--- a/contrib/argm/Trunk.toml
+++ b/contrib/argm/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "argm"
-version = "1.1.1"
+version = "1.1.2"
 repository = "https://github.com/bashtanov/argm"
 license = "PostgreSQL"
 description = "Argm postgresql extension: argmax/argmin and anyold aggregate functions."


### PR DESCRIPTION
At one point, we published `argm` 1.1.2. Bumping this to resolve metadata issues. 