### PR TITLE
Send Base64-encoded checksum to S3

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.12.14"
+version = "0.12.15"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton", "Vinícius Miguel"]
 description = "A package manager for PostgreSQL extensions"
@@ -37,7 +37,9 @@ semver = "1.0.16"
 serde = { version = "1.0.153", features = ["derive"] }
 serde_json = "1.0.91"
 serde_yaml = "0.9.17"
-sha256 = "1.5.0"
+base64 = "0.21"
+hex = "0.4"
+sha2 = "0.10"
 similar = "2.3.0"
 slicedisplay = "0.2.2"
 tar = "0.4.38"

--- a/cli/src/commands/install.rs
+++ b/cli/src/commands/install.rs
@@ -11,6 +11,7 @@ use flate2::read::GzDecoder;
 use log::{error, info, warn};
 use reqwest;
 use reqwest::Url;
+use sha2::{Digest, Sha256};
 use slicedisplay::SliceDisplay;
 use std::ffi::OsStr;
 use std::fs::{self, File};
@@ -588,7 +589,10 @@ fn print_post_installation_guide(manifest: &Manifest) {
 
 fn assert_sha256_matches(contents: &[u8], maybe_hash: Option<String>) -> Result<(), anyhow::Error> {
     if let Some(expected_hash) = maybe_hash {
-        let hash_gotten = sha256::digest(contents);
+        let mut hasher = Sha256::new();
+        hasher.update(contents);
+        let digest = hasher.finalize();
+        let hash_gotten = hex::encode(digest);
 
         anyhow::ensure!(
             hash_gotten == expected_hash,

--- a/registry/Cargo.lock
+++ b/registry/Cargo.lock
@@ -330,17 +330,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
-name = "async-trait"
-version = "0.1.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf6721fb0140e4f897002dd086c06f6c27775df19cfe1fccb21181a48fd2c98"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
 name = "atoi"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,19 +2550,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha256"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7895c8ae88588ccead14ff438b939b0c569cd619116f14b4d13fdff7b8333386"
-dependencies = [
- "async-trait",
- "bytes",
- "hex",
- "sha2",
- "tokio",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3083,6 +3059,7 @@ dependencies = [
  "env_logger",
  "flate2",
  "futures",
+ "hex",
  "nom",
  "rand",
  "reqwest",
@@ -3090,7 +3067,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "sha256",
  "sqlx",
  "tar",
  "thiserror",

--- a/registry/Cargo.toml
+++ b/registry/Cargo.toml
@@ -39,4 +39,4 @@ utoipa-swagger-ui = { version = "4.0.0", features = ["actix-web"] }
 tar = "0.4.40"
 flate2 = "1.0.28"
 bytes = "1.5.0"
-sha256 = "1.4.0"
+hex = "0.4"


### PR DESCRIPTION
AWS S3's [object integrity] just says it needs a checksum, but not the format. We were using `sha256::digest()`, which returned a hex string. Digging around in docs, finally [revealed] that it needs to be Base64-encoded.

So replace the `sha256` crate with `sha2` from the [RustCrypto project], which provides a binary representation of a hash digest, and encode it as appropriate with the `base64` and `hex` crates for S3 validation and Trunk download validation, respectively.

Also pass the digest around as a byte slice and let the uploader code handle encoding it into Base64 for the upload request.

Resolves TEM-2861.

  [object integrity]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html
  [revealed]: https://docs.rs/aws-sdk-s3/latest/aws_sdk_s3/operation/complete_multipart_upload/struct.CompleteMultipartUploadInput.html#method.checksum_sha256
  [RustCrypto project]: https://github.com/RustCrypto/hashes