### PR TITLE
Add plv8

### DIFF
--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -55,7 +55,7 @@ jobs:
     runs-on:
       - self-hosted
       - dind
-      - large-8x8
+      - xlarge-16x16
     container:
       image: quay.io/tembo/trunk-test-tembo:0.0.32
       options: --user root
@@ -79,7 +79,7 @@ jobs:
     runs-on:
       - self-hosted
       - dind
-      - large-8x8
+      - xlarge-16x16
     container:
       image: quay.io/tembo/trunk-test-tembo:0.0.32
       options: --user root

--- a/contrib/plv8/Dockerfile
+++ b/contrib/plv8/Dockerfile
@@ -1,0 +1,11 @@
+ARG PG_VERSION=15
+FROM quay.io/coredb/c-builder:pg${PG_VERSION}
+USER root
+
+ARG RELEASE=v3.2.2
+RUN git clone https://github.com/plv8/plv8.git \
+	&& cd plv8 \
+	&& git fetch origin ${RELEASE} \
+	&& git checkout ${RELEASE} \
+	&& make install \
+	&& ls -lah /usr/share/postgresql/15/extension

--- a/contrib/plv8/Trunk.toml
+++ b/contrib/plv8/Trunk.toml
@@ -1,0 +1,22 @@
+[extension]
+name = "plv8"
+version = "3.2.2"
+repository = "https://github.com/plv8/plv8"
+license = "Copyright"
+description = "A procedural language in JavaScript powered by V8"
+documentation = "https://plv8.github.io/"
+categories = ["procedural_languages"]
+
+[dependencies]
+apt = ["libstdc++6", "libgcc-s1", "libc6"]
+
+[build]
+postgres_version = "15"
+platform = "linux/amd64"
+dockerfile = "Dockerfile"
+install_command = """
+    cd plv8-3.2.2 && make install
+    find /usr/share/postgresql/15/extension -type f -iname '*plv8*' -exec rm {} +
+    find /usr/share/postgresql/15/extension -type f -iname '*plls*' -exec rm {} +
+    find /usr/lib/postgresql/15/lib -type f -iname '*live*' -exec rm {} +
+"""


### PR DESCRIPTION
As of v3.2, the plv8 project no longer includes the `coffeescript` or `livescript` procedural languages. So add a plain old `plv8` package to replace the `plcoffee` package, which should be kept at v3.1.x and deprecated.

Also build on `xlarge-16x16` to escape the merciless OOM killer, which doesn't like the super RAM-intensive plv8 build.