### PR TITLE
bump image for openssl 

### DIFF
--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -11,5 +11,5 @@ RUN cargo install --path .
 FROM quay.io/coredb/debian:11.6-slim
 COPY --from=builder /usr/local/cargo/bin/* /usr/local/bin/
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends ca-certificates
+RUN apt-get install -y --no-install-recommends ca-certificates libssl-dev
 RUN update-ca-certificates

--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -8,8 +8,8 @@ RUN cargo build --release && \
 RUN cargo install --path .
 
 # second stage.
-FROM quay.io/coredb/debian:11.6-slim
+FROM quay.io/tembo/debian:12.5-slim
 COPY --from=builder /usr/local/cargo/bin/* /usr/local/bin/
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends ca-certificates libssl-dev
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y --no-install-recommends ca-certificates
 RUN update-ca-certificates


### PR DESCRIPTION
resolves

```
trunk-registry: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory
```