### PR TITLE
cli(install): in dep. res., look up Trunk project from extension name

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.12.20"
+version = "0.12.21"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton", "Vinícius Miguel"]
 description = "A package manager for PostgreSQL extensions"

--- a/cli/src/commands/install.rs
+++ b/cli/src/commands/install.rs
@@ -51,7 +51,7 @@ pub struct InstallCommand {
     pg_version: Option<u8>,
     /// Skip dependency resolution.
     #[clap(long, short, action)]
-    no_deps: bool,
+    skip_dependencies: bool,
 }
 
 impl InstallCommand {
@@ -162,7 +162,7 @@ impl SubCommand for InstallCommand {
             package_lib_dir,
             sharedir,
             postgres_version,
-            self.no_deps,
+            self.skip_dependencies,
         )
         .await?;
 

--- a/cli/src/v1.rs
+++ b/cli/src/v1.rs
@@ -6,6 +6,12 @@ pub struct TrunkProjectView {
     pub version: String,
     pub postgres_versions: Option<Vec<u8>>,
     pub downloads: Option<Vec<Download>>,
+    pub extensions: Vec<Extension>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Extension {
+    pub extension_name: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
For example: `vectorize` states a dependency on `pgvector` on its control file. Trunk currently fails to install pgvector since it's extension name is `vector`.

This PR aims to fix that by looking up Trunk project names from their extension names whenever necessary.

Example of installing vectorize now:

```
Using pkglibdir: "/usr/lib/postgresql"
Using sharedir: "/usr/share/postgresql"
Using Postgres version: 16
info: Downloading from: https://cdb-plat-use1-prod-pgtrunkio.s3.amazonaws.com/extensions/vectorize/vectorize-pg16-0.12.1.tar.gz
info: Dependent extensions to be installed: ["pg_cron", "pgmq", "vector"]
info: Dependency vector not found in sharedir "/usr/share/postgresql". Installing...
info: Downloading from: https://cdb-plat-use1-prod-pgtrunkio.s3.amazonaws.com/extensions/pgvector/pgvector-pg16-0.6.0.tar.gz

...
```

## `--no-deps` flag

Performs an install without performing dependency resolution. Example output:

```
warn: Skipping dependency resolution! 3 dependencies are unmet.
``` 