### PR TITLE
Add postgis to preload_libraries.

### DIFF
--- a/contrib/pgpointcloud/Trunk.toml
+++ b/contrib/pgpointcloud/Trunk.toml
@@ -6,6 +6,7 @@ license = "Copyright"
 description = "A PostgreSQL extension for storing point cloud (LIDAR) data."
 documentation = "https://pgpointcloud.github.io/pointcloud/"
 categories = ["data_transformations"]
+preload_libraries = ["postgis"]
 
 [dependencies]
 apt = ["libc6"]


### PR DESCRIPTION
Add `postgis` to preload_libraries in Trunk.toml

based on pointcloud.control.in file -- https://github.com/pgpointcloud/pointcloud/blob/master/pgsql/pointcloud.control.in
```
# pointcloud extension
comment = 'data type for lidar point clouds'
default_version = '#POINTCLOUD_VERSION#'
module_pathname = '$libdir/pointcloud-#POINTCLOUD_VERSION_MAJOR#'
relocatable = false
superuser = true
#requires = 'postgis'
```
