### PR TITLE
Update `pg_store_plans` version and add `pg_stat_statements` to preload_libraries.

### DIFF
--- a/contrib/pg_store_plans/Dockerfile
+++ b/contrib/pg_store_plans/Dockerfile
@@ -29,7 +29,7 @@ RUN cd postgres && \
     cd contrib && \
     git clone https://github.com/ossc-db/pg_store_plans.git
 
-ARG RELEASE=1.7
+ARG RELEASE=1.8
 
 # Build extension
 RUN cd postgres/contrib/pg_store_plans && \

--- a/contrib/pg_store_plans/Trunk.toml
+++ b/contrib/pg_store_plans/Trunk.toml
@@ -1,12 +1,12 @@
 [extension]
 name = "pg_store_plans"
-version = "1.7.0"
+version = "1.8.0"
 repository = "https://github.com/ossc-db/pg_store_plans"
 license = "Copyright"
 description = "Track plan statistics of all SQL statements executed."
 documentation = "https://ossc-db.github.io/pg_store_plans/"
 categories = ["metrics"]
-preload_libraries = ["pg_store_plans"]
+preload_libraries = ["pg_store_plans", "pg_stat_statements"]
 
 [build]
 postgres_version = "15"


### PR DESCRIPTION
# Update `pg_store_plans` release version
- As of 2024-Feb-05, version 1.8 has been released
- https://github.com/ossc-db/pg_store_plans/releases/tag/1.8

# Add `pg_stat_statements` to Trunk.toml preload_libraries
- According to the regress.conf file, both `pg_store_plans` and `pg_stat_statements` are required as shared_preload_libraries
- https://github.com/ossc-db/pg_store_plans/blob/1.8/regress.conf
- Therefore, the following update to the [extension] section of the Trunk.toml was made:
```
preload_libraries = ["pg_store_plans", "pg_stat_statements"]
```