### PR TITLE
PLAT-71: Trunk tells user to `create extension <trunk project>`

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.12.22"
+version = "0.12.23"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton", "Vinícius Miguel"]
 description = "A package manager for PostgreSQL extensions"


### PR DESCRIPTION
If the manifest.json doesn't have the `extension_name` in it (for example, if it was built by a considerably older Trunk version), Trunk could produce outputs such as:

```
***************************
* POST INSTALLATION STEPS *
***************************

Enable the extension with:
CREATE EXTENSION IF NOT EXISTS postgresml CASCADE;
```

The above is incorrect, since Postgresml has the `pgml` extension name. In this PR we propose to use the value for `extension_name` supplied by the v1 API if not supplied in the `manifest.json`.

Running `trunk install postgresml` would, then, result in:


```
***************************
* POST INSTALLATION STEPS *
***************************

Enable the extension with:
CREATE EXTENSION IF NOT EXISTS pgml CASCADE;
```