### PR TITLE
readme: also replace relative Markdown links, not just relative images

### DIFF
--- a/registry/tests/v1_integration_test.rs
+++ b/registry/tests/v1_integration_test.rs
@@ -3,7 +3,6 @@ use actix_web::{web, App};
 #[cfg(test)]
 mod tests {
     use super::*;
-    use actix_web::body::to_bytes;
     use actix_web::test;
     use actix_web::web::Bytes;
     use serde_json::Value;
@@ -12,7 +11,6 @@ mod tests {
     use trunk_registry::routes::root::ok;
     use trunk_registry::routes::token::new_token;
     use trunk_registry::token::check_token_input;
-    use trunk_registry::v1::repository::TrunkProjectView;
     use trunk_registry::v1::routes::{
         all_trunk_projects, insert_trunk_project, trunk_project_by_name_and_version,
         trunk_projects_by_name,


### PR DESCRIPTION
Our initial solution had perhaps a bit of tunnel vision by focusing on replacing only relative Markdown images, while it rather should replace all of the Markdown links we can find, images or not.

One example where this proved to be an issue is in https://pgt.dev/extensions/pg_partman. Since their README has stuff like `[pg_partman.md](doc/pg_partman.md)`, pgt.dev incorrectly linked that to https://pgt.dev/extensions/doc/pg_partman.md.

With the changes proposed in this PR, pgt.dev would now link to https://raw.githubusercontent.com/pgpartman/pg_partman/master/doc/pg_partman.md instead.