### PR TITLE
contrib: publish pg_stat_monitor 2.0.4

### DIFF
--- a/contrib/pg_stat_monitor/Dockerfile
+++ b/contrib/pg_stat_monitor/Dockerfile
@@ -6,7 +6,7 @@ FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 RUN git clone https://github.com/percona/pg_stat_monitor.git
 
 # Set project version
-ARG RELEASE=2.0.1
+ARG RELEASE=2.0.4
 
 # Build extension
 RUN cd pg_stat_monitor && \

--- a/contrib/pg_stat_monitor/Trunk.toml
+++ b/contrib/pg_stat_monitor/Trunk.toml
@@ -13,12 +13,12 @@ preload_libraries = ["pg_stat_monitor"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "16"
+postgres_version = "15"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
 install_command = """
     cd pg_stat_monitor && make USE_PGXS=1 install
     set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/16/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/16/lib
+    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
+    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
     """

--- a/contrib/pg_stat_monitor/Trunk.toml
+++ b/contrib/pg_stat_monitor/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_stat_monitor"
-version = "2.0.0"
+version = "2.0.4"
 repository = "https://github.com/percona/pg_stat_monitor"
 license = "PostgreSQL"
 description = "Query Performance Monitoring Tool for PostgreSQL."
@@ -13,12 +13,12 @@ preload_libraries = ["pg_stat_monitor"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "16"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
 install_command = """
     cd pg_stat_monitor && make USE_PGXS=1 install
     set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
+    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/16/extension
+    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/16/lib
     """


### PR DESCRIPTION
This PR updates [pg_stat_monitor](https://github.com/percona/pg_stat_monitor) up to [2.0.4](https://github.com/percona/pg_stat_monitor/releases/tag/2.0.4) version.

I'm not sure if I should also set PG version 16 in Dockerfile. I saw that such change for [pgvector was recently reverted](https://github.com/tembo-io/trunk/pull/696/files), so should I?