### PR TITLE
contrib: publish pg_smtp_client 0.1.0

### DIFF
--- a/contrib/pg_smtp_client/Dockerfile
+++ b/contrib/pg_smtp_client/Dockerfile
@@ -1,0 +1,10 @@
+ARG PG_VERSION=16
+ARG PGRX_VERSION=0.11.4
+
+FROM quay.io/coredb/pgrx-builder:pg${PG_VERSION}-pgrx${PGRX_VERSION}
+
+ARG EXTENSION_VERSION=0.1.0
+
+RUN git clone --depth 1 --branch v${EXTENSION_VERSION} https://github.com/brianpursley/pg_smtp_client && \
+    cd pg_smtp_client && \
+    cargo pgrx package

--- a/contrib/pg_smtp_client/Trunk.toml
+++ b/contrib/pg_smtp_client/Trunk.toml
@@ -1,0 +1,15 @@
+[extension]
+name = "pg_smtp_client"
+version = "0.1.0"
+repository = "https://github.com/brianpursley/pg_smtp_client"
+license = "MIT"
+description = "PostgreSQL extension to send email using SMTP"
+homepage = "https://github.com/brianpursley/pg_smtp_client"
+documentation = "https://github.com/brianpursley/pg_smtp_client"
+categories = ["tooling_admin"]
+
+[build]
+postgres_version = "16"
+platform = "linux/amd64"
+dockerfile = "Dockerfile"
+install_command = "cd pg_smtp_client && cargo pgrx install --release"


### PR DESCRIPTION
I *think* this install_command will work, but I don't see any other extensions doing it this way (except for jsonschema which does it via a Makefile).

If not, I can change to copy files from the target directories manually.