### PR TITLE
cli: retry HTTP requests

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.12.25"
+version = "0.12.26"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton", "Vinícius Miguel"]
 description = "A package manager for PostgreSQL extensions"
@@ -56,6 +56,8 @@ tokio-stream = "0.1.12"
 tokio-task-manager = "0.2.0"
 toml = "0.7.2"
 which = "4.4.0"
+lazy_static = "1.5.0"
+fastrand = "2.1.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.8"

--- a/cli/src/commands/install.rs
+++ b/cli/src/commands/install.rs
@@ -1,6 +1,7 @@
 use super::SubCommand;
 use crate::control_file::ControlFile;
 use crate::manifest::{Manifest, PackagedFile};
+use crate::retry::get_retry;
 use crate::semver::compare_by_semver;
 use crate::v1::TrunkProjectView;
 use anyhow::{anyhow, bail, ensure, Context};
@@ -323,7 +324,7 @@ async fn fetch_archive_from_v1(
 async fn fetch_archive_legacy(registry: &str, name: &str, version: &str) -> anyhow::Result<Url> {
     let endpoint = format!("{}/extensions/{}/{}/download", registry, name, version);
 
-    let response = reqwest::get(endpoint).await?;
+    let response = get_retry(&endpoint).await?;
     let status = response.status();
 
     if status.is_success() {
@@ -423,7 +424,7 @@ async fn install<'name: 'async_recursion>(
     let temp_dir = tempfile::tempdir()?;
     let dest_path = temp_dir.path().join(file_name);
 
-    let response = reqwest::get(url).await?;
+    let response = get_retry(url).await?;
 
     let mut dest_file = File::create(&dest_path)?;
     // write the response body to the file

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,6 +2,7 @@ mod commands;
 mod config;
 mod control_file;
 mod manifest;
+mod retry;
 mod semver;
 mod sync_utils;
 mod trunk_toml;

--- a/cli/src/retry.rs
+++ b/cli/src/retry.rs
@@ -1,0 +1,39 @@
+use std::time::Duration;
+
+use anyhow::bail;
+use lazy_static::lazy_static;
+use reqwest::{IntoUrl, Response};
+
+lazy_static! {
+    static ref CLIENT: reqwest::Client = reqwest::Client::new();
+}
+
+pub async fn get_retry<U: IntoUrl>(url: U) -> anyhow::Result<Response> {
+    let url = url.into_url()?;
+
+    let max_retries = 5;
+    let max_interval = Duration::from_secs(15);
+    let mut interval = Duration::from_millis(500);
+
+    for retry in 1..=max_retries {
+        match CLIENT.get(url.clone()).send().await {
+            Ok(resp) => {
+                if resp.status().is_success() {
+                    return Ok(resp);
+                }
+                let err_msg = resp.text().await.unwrap_or_default();
+                eprintln!("Failed to GET {url}: {err_msg}. Attempt no. {retry}");
+            }
+            Err(err) => {
+                eprintln!("Network error on GET {url}: {err}. Attempt no. {retry}");
+            }
+        }
+
+        let jitter = Duration::from_millis(fastrand::u64(0..1500));
+        interval = std::cmp::min(interval * 2, max_interval); // Double the interval for exponential backoff
+
+        tokio::time::sleep(interval + jitter).await;
+    }
+
+    bail!("Failed to GET {url} after {max_retries} retries.");
+}


### PR DESCRIPTION
Retries HTTP requests up to five times with exponential backoff. Samples from a test run:

```
Failed to GET https://registry.pgtrunk.io/api/v1: . Attempt no. 1
[src/retry.rs:35:9] interval = 1s
[src/retry.rs:35:9] interval + jitter = 1.602s
Failed to GET https://registry.pgtrunk.io/api/v1: . Attempt no. 2
[src/retry.rs:35:9] interval = 2s
[src/retry.rs:35:9] interval + jitter = 2.642s
Failed to GET https://registry.pgtrunk.io/api/v1: . Attempt no. 3
[src/retry.rs:35:9] interval = 4s
[src/retry.rs:35:9] interval + jitter = 4.58s
Failed to GET https://registry.pgtrunk.io/api/v1: . Attempt no. 4
[src/retry.rs:35:9] interval = 8s
[src/retry.rs:35:9] interval + jitter = 9.17s
Failed to GET https://registry.pgtrunk.io/api/v1: . Attempt no. 5
[src/retry.rs:35:9] interval = 15s
[src/retry.rs:35:9] interval + jitter = 16.068s
```