### PR TITLE
Bump pg_lakehouse to the latest release

### DIFF
--- a/contrib/pg_lakehouse/Dockerfile
+++ b/contrib/pg_lakehouse/Dockerfile
@@ -15,12 +15,12 @@ RUN apt-get update && apt-get install -y \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 # Set default Rust version
-RUN /root/.cargo/bin/rustup default stable
+RUN /root/.cargo/bin/rustup default 1.78.0-x86_64-unknown-linux-gnu
 
 # Clone repository
 RUN git clone https://github.com/paradedb/paradedb
 
-ARG LAKEHOUSE_VERSION=v0.7.5
+ARG LAKEHOUSE_VERSION=v0.9.0
 ARG PG_VERSION=15
 
 # Build extension

--- a/contrib/pg_lakehouse/Trunk.toml
+++ b/contrib/pg_lakehouse/Trunk.toml
@@ -1,12 +1,13 @@
 [extension]
 name = "pg_lakehouse"
-version = "0.7.5"
+version = "0.9.0"
 repository = "https://github.com/paradedb/paradedb"
 license = "AGPL-3.0"
 description = "An analytical query engine for Postgres, similar to DuckDB"
 homepage = "https://github.com/paradedb/paradedb/tree/dev/pg_lakehouse"
 documentation = "https://github.com/paradedb/paradedb/blob/dev/pg_lakehouse/README.md"
 categories = ["analytics", "data_transformations"]
+loadable_libraries = [{ library_name = "pg_lakehouse", requires_restart = true }]
 
 [dependencies]
 apt = ["libc6"]


### PR DESCRIPTION
v0.9.0 was released yesterday and some new functions are used in the documentation, etc.

Getting the latest version in trunk for our use.