### PR TITLE
Add pg_analytics

### DIFF
--- a/contrib/pg_analytics/Dockerfile
+++ b/contrib/pg_analytics/Dockerfile
@@ -1,0 +1,28 @@
+ARG PG_VERSION=15
+FROM quay.io/coredb/pgrx-builder:pg${PG_VERSION}-pgrx0.12.1
+USER root
+
+RUN apt-get update && apt-get install -y \
+	build-essential \
+	libssl-dev \
+	clang \
+	cmake \
+	libclang-dev \
+    libopenblas-dev \
+	pkg-config
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+# Clone repository
+RUN git clone https://github.com/paradedb/pg_analytics
+
+ARG PG_ANALYTICS_VERSION=v0.1.2
+ARG PG_VERSION=15
+
+# Build extension
+RUN cd pg_analytics && \
+	git fetch origin ${PG_ANALYTICS_VERSION} && \
+	git checkout ${PG_ANALYTICS_VERSION} && \
+    cargo pgrx init --pg${PG_VERSION} /usr/bin/pg_config && \
+    cargo pgrx package

--- a/contrib/pg_analytics/Trunk.toml
+++ b/contrib/pg_analytics/Trunk.toml
@@ -17,7 +17,7 @@ postgres_version = "15"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
 install_command = """
-    cd paradedb/
+    cd pg_analytics/
     mv target/release/pg_analytics-pg15/usr/lib/postgresql/15/lib/* /usr/lib/postgresql/15/lib
     mv target/release/pg_analytics-pg15/usr/share/postgresql/15/extension/* /usr/share/postgresql/15/extension
 """

--- a/contrib/pg_analytics/Trunk.toml
+++ b/contrib/pg_analytics/Trunk.toml
@@ -1,0 +1,23 @@
+[extension]
+name = "pg_analytics"
+version = "0.1.2"
+repository = "https://github.com/paradedb/pg_analytics"
+license = "AGPL-3.0"
+description = "pg_analytics (formerly named pg_lakehouse) puts DuckDB inside Postgres"
+homepage = "https://github.com/paradedb/pg_analytics"
+documentation = "https://github.com/paradedb/pg_analytics/blob/dev/README.md"
+categories = ["analytics", "data_transformations"]
+loadable_libraries = [{ library_name = "pg_analytics", requires_restart = true }]
+
+[dependencies]
+apt = ["libc6"]
+
+[build]
+postgres_version = "15"
+platform = "linux/amd64"
+dockerfile = "Dockerfile"
+install_command = """
+    cd paradedb/
+    mv target/release/pg_analytics-pg15/usr/lib/postgresql/15/lib/* /usr/lib/postgresql/15/lib
+    mv target/release/pg_analytics-pg15/usr/share/postgresql/15/extension/* /usr/share/postgresql/15/extension
+"""


### PR DESCRIPTION
This was once named pg_lakehouse, but they've broken it out and changed the name. They've now actually made release tags for it (v0.1.2 is part of ParadeDB v0.9.3) so it feels like time to switch names ourselves.