### PR TITLE
Update pg_stat_monitor to 2.1.0

### DIFF
--- a/contrib/pg_stat_monitor/Dockerfile
+++ b/contrib/pg_stat_monitor/Dockerfile
@@ -6,7 +6,7 @@ FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 RUN git clone https://github.com/percona/pg_stat_monitor.git
 
 # Set project version
-ARG RELEASE=2.0.4
+ARG RELEASE=2.1.0
 
 # Build extension
 RUN cd pg_stat_monitor && \

--- a/contrib/pg_stat_monitor/Trunk.toml
+++ b/contrib/pg_stat_monitor/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_stat_monitor"
-version = "2.0.4"
+version = "2.1.0"
 repository = "https://github.com/percona/pg_stat_monitor"
 license = "PostgreSQL"
 description = "Query Performance Monitoring Tool for PostgreSQL."


### PR DESCRIPTION
This PR updates [pg_stat_monitor](https://github.com/percona/pg_stat_monitor) to [2.1.0](https://github.com/percona/pg_stat_monitor/releases/tag/2.1.0) version.