### PR TITLE
pg_ivm 1.9

### DIFF
--- a/contrib/pg_ivm/Dockerfile
+++ b/contrib/pg_ivm/Dockerfile
@@ -4,7 +4,7 @@ FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 # Clone repository
 RUN git clone https://github.com/sraoss/pg_ivm.git
 
-ARG RELEASE=v1.5.1
+ARG RELEASE=v1.9
 
 RUN cd pg_ivm && \
     git fetch origin ${RELEASE} && \

--- a/contrib/pg_ivm/Trunk.toml
+++ b/contrib/pg_ivm/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_ivm"
-version = "1.5.0"
+version = "1.9.0"
 repository = "https://github.com/sraoss/pg_ivm"
 license = "PostgreSQL"
 description = "IVM (Incremental View Maintenance) implementation as a PostgreSQL extension"


### PR DESCRIPTION
https://github.com/sraoss/pg_ivm/tree/v1.9

tag is `v1.9` not `v1.9.0`, so not using full semver in the `Dockerfile`