### PR TITLE
Switch to simple version

### DIFF
--- a/contrib/tembo_ivm/Dockerfile
+++ b/contrib/tembo_ivm/Dockerfile
@@ -4,7 +4,7 @@ FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 # Clone repository
 RUN git clone https://github.com/tembo-io/pg_ivm.git
 
-ARG RELEASE=v1.9+tembo
+ARG RELEASE=v1.9
 
 RUN cd pg_ivm && \
     git fetch origin ${RELEASE} && \

--- a/contrib/tembo_ivm/Trunk.toml
+++ b/contrib/tembo_ivm/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "tembo_ivm"
-version = "1.9"
+version = "1.9.0"
 repository = "https://github.com/tembo-io/pg_ivm"
 license = "PostgreSQL"
 description = "IVM (Incremental View Maintenance) implementation with Partitioned Support"


### PR DESCRIPTION
The +tembo hack failed silently: the build checks all pass, but there was actually a serde error reading the version number.

It's slightly more annoying to deal with but I'm just going to use the same tag as upstream to get unblocked and get this in trunk.