### PR TITLE
Enable manifest pushes for PG17

### DIFF
--- a/.github/workflows/builder-images.yml
+++ b/.github/workflows/builder-images.yml
@@ -70,7 +70,7 @@ jobs:
       - large-8x8
     strategy:
       matrix:
-        pg_version: ["14", "15", "16"]
+        pg_version: ["14", "15", "16", "17"]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4


### PR DESCRIPTION
These couldn't be re-enabled until PG17 images were in quay. Now that some are, I think this should be the last step to completing PG17 tooling.