### PR TITLE
Actually release PG17-compatible trunk binary

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 authors = ["Ian Stanton", "Vinícius Miguel"]
 description = "A package manager for PostgreSQL extensions"


### PR DESCRIPTION
This should be ready to go, will test with remote cargo install after it's pushed.