### PR TITLE
Get rid of the cycle in this build system

### DIFF
--- a/images/trunk-test-tembo/Dockerfile
+++ b/images/trunk-test-tembo/Dockerfile
@@ -1,6 +1,17 @@
 ARG PG_VERSION=15
+ARG TAG=latest
 
-FROM quay.io/tembo/tembo-pg-cnpg:pg${PG_VERSION}-e112cf3 
+FROM rust:1.78-bookworm as builder
+
+ARG TRUNK_VER=0.14.0
+
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL sparse
+RUN cargo install --version $TRUNK_VER pg-trunk
+
+FROM quay.io/tembo/tembo-pg-cnpg:pg${PG_VERSION}-e112cf3
+
+# Install trunk
+COPY --from=builder /usr/local/cargo/bin/trunk /usr/bin/trunk
 
 USER root
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
trunk needs this image to have the latest trunk in it. Rather than get it from its own repo, or cargo, it depends on `tembo-images`, which installs trunk there. But those images install extensions using `trunk`, which cannot be published for pg17 until the trunk publish step is complete, which depends on those same pg17 images.

This just forces the latest trunk within the tembo-trunk-test images themselves, sidestepping the need to upgrade the `cpng`/`slim` images and solving what appears to be a boostrapping problem.