### PR TITLE
Add pg17 publish suffix to trunk CLI

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 authors = ["Ian Stanton", "Vinícius Miguel"]
 description = "A package manager for PostgreSQL extensions"

--- a/cli/src/commands/publish.rs
+++ b/cli/src/commands/publish.rs
@@ -255,7 +255,7 @@ impl SubCommand for PublishCommand {
                 // If no file is specified, read file from working dir with format
                 // .trunk/<extension_name>-<version>.tar.gz.
                 // Error if file is not found
-                let possible_suffixes = ["", "-pg14", "-pg15", "-pg16"];
+                let possible_suffixes = ["", "-pg14", "-pg15", "-pg16", "-pg17"];
 
                 for suffix in possible_suffixes {
                     let file = format!(


### PR DESCRIPTION
Missed this earlier; when trunk goes to publish extensions it has a whitelist of suffixes it iterates over.