### PR TITLE
Update remaining core extensions to Postgres 17

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.15.3"
+version = "0.15.4"
 edition = "2021"
 authors = ["Ian Stanton", "Vinícius Miguel"]
 description = "A package manager for PostgreSQL extensions"

--- a/contrib/amcheck/Dockerfile
+++ b/contrib/amcheck/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/amcheck && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/amcheck/Trunk.toml
+++ b/contrib/amcheck/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "amcheck"
-version = "1.3.0"
+version = "1.4.0"
 repository = "https://github.com/postgres/postgres/tree/master/contrib/amcheck"
 license = "PostgreSQL"
 description = "The amcheck module provides functions that allow you to verify the logical consistency of the structure of relations."
@@ -12,12 +12,7 @@ categories = ["index_table_optimizations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/amcheck && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/amcheck install USE_PGXS=1"

--- a/contrib/auth_delay/Dockerfile
+++ b/contrib/auth_delay/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -13,16 +13,11 @@ RUN apt-get update && apt-get install -y \
 	libssl-dev \
 	libxml2-utils \
 	xsltproc \
-	ccache
+	ccache \
+	libkrb5-dev
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/auth_delay && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/auth_delay/Trunk.toml
+++ b/contrib/auth_delay/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "auth_delay"
-version = "15.3.0"
+version = "17.2.0"
 repository = "https://github.com/postgres/postgres/tree/master/contrib/auth_delay"
 license = "PostgreSQL"
 description = "auth_delay causes the server to pause briefly before reporting authentication failure, to make brute-force attacks on database passwords more difficult."
@@ -10,13 +10,7 @@ categories = ["security"]
 loadable_libraries = [{ library_name = "auth_delay", requires_restart = true }]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/auth_delay && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
-
+install_command = "make -C postgres/contrib/auth_delay install USE_PGXS=1"

--- a/contrib/autoinc/Dockerfile
+++ b/contrib/autoinc/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=17
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
     build-essential \
     libreadline-dev \
@@ -15,15 +15,10 @@ RUN apt-get update && apt-get install -y \
     xsltproc \
     ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_17_2
-
-RUN cd postgres && \
-    git fetch origin ${PG_RELEASE} && \
-    git checkout ${PG_RELEASE} && \
-    ./configure && \
-    cd contrib/spi && \
-    make
-
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+    && printf "MODULES = autoinc\nEXTENSION = autoinc\nDATA = \$(wildcard autoinc--*.sql)\nPG_CONFIG ?= pg_config\nPGXS := \$(shell \$(PG_CONFIG) --pgxs)\ninclude \$(PGXS)\n" > postgres/contrib/spi/Makefile \
+    && cat postgres/contrib/spi/Makefile \
+    && make -C postgres/contrib/spi USE_PGXS=1

--- a/contrib/autoinc/Trunk.toml
+++ b/contrib/autoinc/Trunk.toml
@@ -15,10 +15,4 @@ apt = ["libc6"]
 postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/spi && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/autoinc* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/autoinc* /usr/lib/postgresql/15/lib
-    """
-
+install_command = "make -C postgres/contrib/spi install USE_PGXS=1"

--- a/contrib/basebackup_to_shell/Dockerfile
+++ b/contrib/basebackup_to_shell/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,9 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/basebackup_to_shell && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& (cd postgres && ./configure --datarootdir "$(pg_config --sharedir)" --libdir "$(pg_config --pkglibdir)") \
+	&& make -C postgres/contrib/${EXTENSION_NAME}

--- a/contrib/basebackup_to_shell/Trunk.toml
+++ b/contrib/basebackup_to_shell/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "basebackup_to_shell"
-version = "15.3.0"
+version = "17.2.0"
 repository = "https://github.com/postgres/postgres/tree/master/contrib/basebackup_to_shell"
 license = "PostgreSQL"
 description = "basebackup_to_shell adds a custom basebackup target called shell."
@@ -13,13 +13,7 @@ loadable_libraries = [{ library_name = "basebackup_to_shell", requires_restart =
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/basebackup_to_shell && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
-
+install_command = "make -C postgres/contrib/basebackup_to_shell install"

--- a/contrib/basic_archive/Dockerfile
+++ b/contrib/basic_archive/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION=17
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/basic_archive && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/basic_archive/Trunk.toml
+++ b/contrib/basic_archive/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "basic_archive"
-version = "15.3.0"
+version = "17.2.0"
 repository = "https://github.com/postgres/postgres/tree/master/contrib/basic_archive"
 license = "PostgreSQL"
 description = "This module copies completed WAL segment files to the specified directory."
@@ -13,13 +13,7 @@ loadable_libraries = [{ library_name = "basic_archive", requires_restart = true 
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/basic_archive && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
-
+install_command = "make -C postgres/contrib/basic_archive install USE_PGXS=1"

--- a/contrib/insert_username/Dockerfile
+++ b/contrib/insert_username/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
     build-essential \
     libreadline-dev \
@@ -15,14 +15,10 @@ RUN apt-get update && apt-get install -y \
     xsltproc \
     ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-    git fetch origin ${PG_RELEASE} && \
-    git checkout ${PG_RELEASE} && \
-    ./configure && \
-    cd contrib/spi && \
-    make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+    && printf "MODULES = insert_username\nEXTENSION = insert_username\nDATA = \$(wildcard insert_username--*.sql)\nPG_CONFIG ?= pg_config\nPGXS := \$(shell \$(PG_CONFIG) --pgxs)\ninclude \$(PGXS)\n" > postgres/contrib/spi/Makefile \
+    && cat postgres/contrib/spi/Makefile \
+    && make -C postgres/contrib/spi USE_PGXS=1

--- a/contrib/insert_username/Trunk.toml
+++ b/contrib/insert_username/Trunk.toml
@@ -13,12 +13,7 @@ categories = ["auditing_logging"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/spi && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/insert_username* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/insert_username* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/spi install USE_PGXS=1"

--- a/contrib/intagg/Dockerfile
+++ b/contrib/intagg/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/intagg && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/intagg/Trunk.toml
+++ b/contrib/intagg/Trunk.toml
@@ -9,12 +9,7 @@ documentation = "https://www.postgresql.org/docs/current/intagg.html"
 categories = ["data_transformations"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/intagg && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/intagg install USE_PGXS=1"

--- a/contrib/intarray/Dockerfile
+++ b/contrib/intarray/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/intarray && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/intarray/Trunk.toml
+++ b/contrib/intarray/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["data_transformations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/intarray && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/intarray install USE_PGXS=1"

--- a/contrib/isn/Dockerfile
+++ b/contrib/isn/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/isn && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/isn/Trunk.toml
+++ b/contrib/isn/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["data_transformations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/isn && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/isn install USE_PGXS=1"

--- a/contrib/jsonb_plperl/Dockerfile
+++ b/contrib/jsonb_plperl/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -17,16 +17,9 @@ RUN apt-get update && apt-get install -y \
 	libperl-dev \
 	perl
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-# Set project version
-ARG PG_RELEASE=REL_15_3
-
-# Build extension
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure --with-perl && \
-	cd contrib/jsonb_plperl && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& (cd postgres && ./configure --with-perl --datarootdir "$(pg_config --sharedir)" --libdir "$(pg_config --pkglibdir)") \
+	&& make -C postgres/contrib/${EXTENSION_NAME}

--- a/contrib/jsonb_plperl/Trunk.toml
+++ b/contrib/jsonb_plperl/Trunk.toml
@@ -12,14 +12,10 @@ categories = ["data_transformations"]
 apt = ["libc6", "libperl5.34"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
 install_command = """
-    cd postgres/contrib/jsonb_plperl && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/jsonb_plperl.* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/share/extension/jsonb_plperl--* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
-
+    make -C postgres/contrib/jsonb_plperl install
+    rm "$(pg_config --sharedir)"/extension/jsonb_plperlu{--*,.*}
+"""

--- a/contrib/jsonb_plperlu/Dockerfile
+++ b/contrib/jsonb_plperlu/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -17,16 +17,9 @@ RUN apt-get update && apt-get install -y \
 	libperl-dev \
 	perl
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-# Set project version
-ARG PG_RELEASE=REL_15_3
-
-# Build extension
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure --with-perl && \
-	cd contrib/jsonb_plperl && \
-	make
+# Clone repository and build extension.
+# ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& (cd postgres && ./configure --with-perl --datarootdir "$(pg_config --sharedir)" --libdir "$(pg_config --pkglibdir)") \
+	&& make -C postgres/contrib/jsonb_plperl

--- a/contrib/jsonb_plperlu/Trunk.toml
+++ b/contrib/jsonb_plperlu/Trunk.toml
@@ -9,12 +9,10 @@ documentation = "https://www.postgresql.org/docs/current/datatype-json.html"
 categories = ["data_transformations"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
 install_command = """
-    cd postgres/contrib/jsonb_plperl && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/jsonb_plperlu* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+    make -C postgres/contrib/jsonb_plperl install
+    rm "$(pg_config --sharedir)"/extension/jsonb_plperl{--*,.*}
+"""

--- a/contrib/lo/Dockerfile
+++ b/contrib/lo/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/lo && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/lo/Trunk.toml
+++ b/contrib/lo/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["data_transformations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/lo && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/lo install USE_PGXS=1"

--- a/contrib/moddatetime/Dockerfile
+++ b/contrib/moddatetime/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
     build-essential \
     libreadline-dev \
@@ -15,14 +15,10 @@ RUN apt-get update && apt-get install -y \
     xsltproc \
     ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-    git fetch origin ${PG_RELEASE} && \
-    git checkout ${PG_RELEASE} && \
-    ./configure && \
-    cd contrib/spi && \
-    make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+    && printf "MODULES = moddatetime\nEXTENSION = moddatetime\nDATA = \$(wildcard moddatetime--*.sql)\nPG_CONFIG ?= pg_config\nPGXS := \$(shell \$(PG_CONFIG) --pgxs)\ninclude \$(PGXS)\n" > postgres/contrib/spi/Makefile \
+    && cat postgres/contrib/spi/Makefile \
+    && make -C postgres/contrib/spi USE_PGXS=1

--- a/contrib/moddatetime/Trunk.toml
+++ b/contrib/moddatetime/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["auditing_logging"]
 apt = ["libc6", "libpython3.10"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/spi && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/moddatetime* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/moddatetime* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/spi install USE_PGXS=1"

--- a/contrib/old_snapshot/Dockerfile
+++ b/contrib/old_snapshot/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/old_snapshot && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/old_snapshot/Trunk.toml
+++ b/contrib/old_snapshot/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["metrics"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/old_snapshot && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/old_snapshot install USE_PGXS=1"

--- a/contrib/pageinspect/Dockerfile
+++ b/contrib/pageinspect/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/pageinspect && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/pageinspect/Trunk.toml
+++ b/contrib/pageinspect/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["metrics"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/pageinspect && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/pageinspect install USE_PGXS=1"

--- a/contrib/passwordcheck/Dockerfile
+++ b/contrib/passwordcheck/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/passwordcheck && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/passwordcheck/Trunk.toml
+++ b/contrib/passwordcheck/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "passwordcheck"
-version = "15.3.0"
+version = "17.2.0"
 repository = "https://github.com/postgres/postgres/tree/master/contrib/passwordcheck"
 license = "PostgreSQL"
 description = "The passwordcheck module checks users' passwords whenever they are set with CREATE ROLE or ALTER ROLE."
@@ -13,13 +13,7 @@ loadable_libraries = [{ library_name = "passwordcheck", requires_restart = true 
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/passwordcheck && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
-
+install_command = "make -C postgres/contrib/passwordcheck install USE_PGXS=1"

--- a/contrib/pg_buffercache/Dockerfile
+++ b/contrib/pg_buffercache/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/pg_buffercache && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/pg_buffercache/Trunk.toml
+++ b/contrib/pg_buffercache/Trunk.toml
@@ -13,12 +13,7 @@ categories = ["metrics"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/pg_buffercache && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/pg_buffercache install USE_PGXS=1"

--- a/contrib/pg_freespacemap/Dockerfile
+++ b/contrib/pg_freespacemap/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/pg_freespacemap && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/pg_freespacemap/Trunk.toml
+++ b/contrib/pg_freespacemap/Trunk.toml
@@ -9,12 +9,7 @@ documentation = "https://www.postgresql.org/docs/current/pgfreespacemap.html"
 categories = ["metrics"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/pg_freespacemap && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/pg_freespacemap install USE_PGXS=1"

--- a/contrib/pg_prewarm/Dockerfile
+++ b/contrib/pg_prewarm/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/pg_prewarm && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/pg_prewarm/Trunk.toml
+++ b/contrib/pg_prewarm/Trunk.toml
@@ -13,12 +13,7 @@ preload_libraries = ["pg_prewarm"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/pg_prewarm && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/pg_prewarm install USE_PGXS=1"

--- a/contrib/pg_stat_statements/Dockerfile
+++ b/contrib/pg_stat_statements/Dockerfile
@@ -1,9 +1,9 @@
 # Set up variables for build.
-ARG PG_VERSION=17
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -16,14 +16,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/pg_stat_statements && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/pg_stat_statements/Trunk.toml
+++ b/contrib/pg_stat_statements/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_stat_statements"
-version = "1.10.0"
+version = "1.11.0"
 repository = "https://github.com/postgres/postgres/tree/master/contrib/pg_stat_statements"
 license = "PostgreSQL"
 description = "The pg_stat_statements module provides a means for tracking planning and execution statistics of all SQL statements executed by a server."
@@ -12,12 +12,7 @@ categories = ["featured", "metrics"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/pg_stat_statements && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/pg_stat_statements install USE_PGXS=1"

--- a/contrib/pg_surgery/Dockerfile
+++ b/contrib/pg_surgery/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/pg_surgery && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/pg_surgery/Trunk.toml
+++ b/contrib/pg_surgery/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["debugging"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/pg_surgery && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/pg_surgery install USE_PGXS=1"

--- a/contrib/pg_trgm/Dockerfile
+++ b/contrib/pg_trgm/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/pg_trgm && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/pg_trgm/Trunk.toml
+++ b/contrib/pg_trgm/Trunk.toml
@@ -12,13 +12,7 @@ categories = ["search"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/pg_trgm && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
-
+install_command = "make -C postgres/contrib/pg_trgm install USE_PGXS=1"

--- a/contrib/pg_visibility/Dockerfile
+++ b/contrib/pg_visibility/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/pg_visibility && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/pg_visibility/Trunk.toml
+++ b/contrib/pg_visibility/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["metrics"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/pg_visibility && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/pg_visibility install USE_PGXS=1"

--- a/contrib/pg_walinspect/Dockerfile
+++ b/contrib/pg_walinspect/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/pg_walinspect && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/pg_walinspect/Trunk.toml
+++ b/contrib/pg_walinspect/Trunk.toml
@@ -13,12 +13,7 @@ categories = ["metrics"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/pg_walinspect && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/pg_walinspect install USE_PGXS=1"

--- a/contrib/pgcrypto/Dockerfile
+++ b/contrib/pgcrypto/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/pgcrypto && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/pgcrypto/Trunk.toml
+++ b/contrib/pgcrypto/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["security"]
 apt = ["zlib1g", "libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/pgcrypto && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/pgcrypto install USE_PGXS=1"

--- a/contrib/pgrowlocks/Dockerfile
+++ b/contrib/pgrowlocks/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/pgrowlocks && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/pgrowlocks/Trunk.toml
+++ b/contrib/pgrowlocks/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["metrics"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/pgrowlocks && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/pgrowlocks install USE_PGXS=1"

--- a/contrib/pgstattuple/Dockerfile
+++ b/contrib/pgstattuple/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/pgstattuple && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/pgstattuple/Trunk.toml
+++ b/contrib/pgstattuple/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["metrics"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/pgstattuple && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/pgstattuple install USE_PGXS=1"

--- a/contrib/plperl/Dockerfile
+++ b/contrib/plperl/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -18,14 +18,9 @@ RUN apt-get update && apt-get install -y \
 	libperl-dev \
 	perl
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git 
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-    git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure --with-perl && \
-	cd src/pl/plperl && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& (cd postgres && ./configure --with-perl --datarootdir "$(pg_config --sharedir)" --libdir "$(pg_config --pkglibdir)") \
+	&& make -C postgres/src/pl/${EXTENSION_NAME}

--- a/contrib/plperl/Trunk.toml
+++ b/contrib/plperl/Trunk.toml
@@ -12,15 +12,10 @@ categories = ["procedural_languages"]
 apt = ["libc6", "libperl5.34"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
 install_command = """
     make -C postgres/src/pl/plperl install
-    set -x
-    mv /usr/local/pgsql/share/extension/plperl.* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/share/extension/plperl--* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/plperl.* /usr/lib/postgresql/15/lib
-    mv /usr/local/pgsql/lib/plperl--* /usr/lib/postgresql/15/lib
+    rm "$(pg_config --sharedir)"/extension/plperlu{--*,.*}
 """
-

--- a/contrib/plperlu/Dockerfile
+++ b/contrib/plperlu/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -18,14 +18,9 @@ RUN apt-get update && apt-get install -y \
 	libperl-dev \
 	perl
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git 
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-    git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure --with-perl && \
-	cd src/pl/plperl && \
-	make
+# Clone repository and build extension.
+# ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& (cd postgres && ./configure --with-perl --datarootdir "$(pg_config --sharedir)" --libdir "$(pg_config --pkglibdir)") \
+	&& make -C postgres/src/pl/plperl

--- a/contrib/plperlu/Trunk.toml
+++ b/contrib/plperlu/Trunk.toml
@@ -12,13 +12,10 @@ categories = ["procedural_languages"]
 apt = ["libc6", "libperl5.34"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
 install_command = """
     make -C postgres/src/pl/plperl install
-    set -x
-    mv /usr/local/pgsql/share/extension/plperlu* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/plperl* /usr/lib/postgresql/15/lib
+    rm "$(pg_config --sharedir)"/extension/plperl{--*,.*}
 """
-

--- a/contrib/plpgsql/Dockerfile
+++ b/contrib/plpgsql/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -16,14 +16,9 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git 
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-    git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd src/pl/plpgsql && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& (cd postgres && ./configure --datarootdir "$(pg_config --sharedir)" --libdir "$(pg_config --pkglibdir)") \
+	&& make -C postgres/src/pl/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/plpgsql/Trunk.toml
+++ b/contrib/plpgsql/Trunk.toml
@@ -12,13 +12,7 @@ categories = ["procedural_languages"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    make -C postgres/src/pl/plpgsql install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-"""
-
+install_command = "make -C postgres/src/pl/plpgsql install"

--- a/contrib/pltcl/Dockerfile
+++ b/contrib/pltcl/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -17,14 +17,9 @@ RUN apt-get update && apt-get install -y \
 	ccache \
 	tcl-dev
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git 
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-    git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure --with-tcl && \
-	cd src/pl/tcl && \
-	make
+# Clone repository and build extension.
+# ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& (cd postgres && ./configure --with-tcl --datarootdir "$(pg_config --sharedir)" --libdir "$(pg_config --pkglibdir)") \
+	&& make -C postgres/src/pl/tcl

--- a/contrib/pltcl/Trunk.toml
+++ b/contrib/pltcl/Trunk.toml
@@ -1,6 +1,7 @@
 [extension]
 name = "pltcl"
 version = "1.0.0"
+license = "PostgreSQL"
 repository = "https://github.com/postgres/postgres/tree/master/src/pl/tcl"
 description = "The PL/Tcl procedural language for PostgreSQL."
 homepage = "https://www.postgresql.org"
@@ -11,14 +12,10 @@ categories = ["procedural_languages"]
 apt = ["libtcl8.6.so", "libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
 install_command = """
     make -C postgres/src/pl/tcl install
-    set -x
-    mv /usr/local/pgsql/share/extension/pltcl.* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/share/extension/pltcl--* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/pltcl* /usr/lib/postgresql/15/lib
+    rm "$(pg_config --sharedir)"/extension/pltclu{--*,.*}
 """
-

--- a/contrib/pltclu/Dockerfile
+++ b/contrib/pltclu/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -17,14 +17,9 @@ RUN apt-get update && apt-get install -y \
 	ccache \
 	tcl-dev
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git 
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-    git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure --with-tcl && \
-	cd src/pl/tcl && \
-	make
+# Clone repository and build extension.
+# ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& (cd postgres && ./configure --with-tcl --datarootdir "$(pg_config --sharedir)" --libdir "$(pg_config --pkglibdir)") \
+	&& make -C postgres/src/pl/tcl

--- a/contrib/pltclu/Trunk.toml
+++ b/contrib/pltclu/Trunk.toml
@@ -1,6 +1,7 @@
 [extension]
 name = "pltclu"
 version = "1.0.0"
+license = "PostgreSQL"
 repository = "https://github.com/postgres/postgres/tree/master/src/pl/tcl"
 description = "The PL/Tclu procedural language for PostgreSQL."
 homepage = "https://www.postgresql.org"
@@ -11,13 +12,10 @@ categories = ["procedural_languages"]
 apt = ["libtcl8.6.so", "libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
 install_command = """
     make -C postgres/src/pl/tcl install
-    set -x
-    mv /usr/local/pgsql/share/extension/pltclu* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/pltcl* /usr/lib/postgresql/15/lib
+    rm "$(pg_config --sharedir)"/extension/pltcl{--*,.*}
 """
-

--- a/contrib/refint/Dockerfile
+++ b/contrib/refint/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
     build-essential \
     libreadline-dev \
@@ -15,14 +15,10 @@ RUN apt-get update && apt-get install -y \
     xsltproc \
     ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-    git fetch origin ${PG_RELEASE} && \
-    git checkout ${PG_RELEASE} && \
-    ./configure && \
-    cd contrib/spi && \
-    make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+    && printf "MODULES = refint\nEXTENSION = refint\nDATA = \$(wildcard refint--*.sql)\nPG_CONFIG ?= pg_config\nPGXS := \$(shell \$(PG_CONFIG) --pgxs)\ninclude \$(PGXS)\n" > postgres/contrib/spi/Makefile \
+    && cat postgres/contrib/spi/Makefile \
+    && make -C postgres/contrib/spi USE_PGXS=1

--- a/contrib/refint/Trunk.toml
+++ b/contrib/refint/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["tooling_admin"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/spi && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/refint* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/refint* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/spi install USE_PGXS=1"

--- a/contrib/seg/Dockerfile
+++ b/contrib/seg/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/seg && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/seg/Trunk.toml
+++ b/contrib/seg/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["data_transformations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/seg && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/seg install USE_PGXS=1"

--- a/contrib/sepgsql/Dockerfile
+++ b/contrib/sepgsql/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -14,16 +14,11 @@ RUN apt-get update && apt-get install -y \
 	libxml2-utils \
 	xsltproc \
 	ccache \
-	libselinux1-dev
+	libselinux1-dev \
+	libkrb5-dev
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/sepgsql && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/sepgsql/Trunk.toml
+++ b/contrib/sepgsql/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "sepgsql"
-version = "15.3.0"
+version = "17.3.0"
 repository = "https://github.com/postgres/postgres/tree/master/contrib/sepgsql"
 license = "PostgreSQL"
 description = "sepgsql is a loadable module that supports label-based mandatory access control (MAC) based on SELinux security policy."
@@ -13,13 +13,7 @@ loadable_libraries = [{ library_name = "sepgsql", requires_restart = true }]
 apt = ["libselinux1", "libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/sepgsql && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
-
+install_command = "make -C postgres/contrib/sepgsql install USE_PGXS=1"

--- a/contrib/sslinfo/Dockerfile
+++ b/contrib/sslinfo/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -13,16 +13,11 @@ RUN apt-get update && apt-get install -y \
 	libssl-dev \
 	libxml2-utils \
 	xsltproc \
-	ccache
+	ccache \
+	libkrb5-dev
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure --with-openssl && \
-	cd contrib/sslinfo && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/sslinfo/Trunk.toml
+++ b/contrib/sslinfo/Trunk.toml
@@ -13,12 +13,7 @@ categories = ["security"]
 apt = ["libc6", "openssl"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/sslinfo && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/sslinfo install USE_PGXS=1"

--- a/contrib/tablefunc/Dockerfile
+++ b/contrib/tablefunc/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/tablefunc && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/tablefunc/Trunk.toml
+++ b/contrib/tablefunc/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["data_transformations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/tablefunc && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/tablefunc install USE_PGXS=1"

--- a/contrib/tcn/Dockerfile
+++ b/contrib/tcn/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/tcn && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/tcn/Trunk.toml
+++ b/contrib/tcn/Trunk.toml
@@ -9,12 +9,7 @@ documentation = "https://www.postgresql.org/docs/current/tcn.html"
 categories = ["auditing_logging"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/tcn && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/tcn install USE_PGXS=1"

--- a/contrib/test_decoding/Dockerfile
+++ b/contrib/test_decoding/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/test_decoding && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/test_decoding/Trunk.toml
+++ b/contrib/test_decoding/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "test_decoding"
-version = "15.3.0"
+version = "17.2.0"
 repository = "https://github.com/postgres/postgres/tree/master/contrib/test_decoding"
 license = "PostgreSQL"
 description = "test_decoding receives WAL through the logical decoding mechanism and decodes it into text representations of the operations performed."
@@ -12,12 +12,7 @@ categories = ["change_data_capture"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/test_decoding && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/test_decoding install USE_PGXS=1"

--- a/contrib/tsm_system_rows/Dockerfile
+++ b/contrib/tsm_system_rows/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/tsm_system_rows && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/tsm_system_rows/Trunk.toml
+++ b/contrib/tsm_system_rows/Trunk.toml
@@ -9,12 +9,7 @@ documentation = "https://www.postgresql.org/docs/current/tsm-system-rows.html"
 categories = ["data_transformations"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/tsm_system_rows && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/tsm_system_rows install USE_PGXS=1"

--- a/contrib/tsm_system_time/Dockerfile
+++ b/contrib/tsm_system_time/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib/tsm_system_time && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/tsm_system_time/Trunk.toml
+++ b/contrib/tsm_system_time/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["data_transformations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/tsm_system_time && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/tsm_system_time install USE_PGXS=1"

--- a/contrib/uuid_ossp/Dockerfile
+++ b/contrib/uuid_ossp/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -16,14 +16,8 @@ RUN apt-get update && apt-get install -y \
 	ccache \
 	uuid-dev
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure --with-uuid=e2fs && \
-	cd contrib/uuid-ossp && \
-	make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/uuid-ossp USE_PGXS=1

--- a/contrib/uuid_ossp/Trunk.toml
+++ b/contrib/uuid_ossp/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["data_transformations"]
 apt = ["libuuid1", "libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/uuid-ossp && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/uuid-ossp install USE_PGXS=1"

--- a/contrib/xml2/Dockerfile
+++ b/contrib/xml2/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,14 +15,8 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure --with-libxml && \
-	cd contrib/xml2 && \
-	make
+	# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/xml2/Trunk.toml
+++ b/contrib/xml2/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["data_transformations"]
 apt = ["libxml2", "libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/xml2 && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgres/contrib/xml2 install USE_PGXS=1"


### PR DESCRIPTION
Some have new versions, either from their control files or from Postgres itself, so adjust accordingly. Simplify the build scripting to shallowly clone the Postgres repo at the release tag, skip configuring Postgres, and use `make USE_PGXS=1` to install to the proper locations for the system Postgres, rather than the `/usr/local` default from configuring Postgres, eliminating the need for `mv`s in the install command.

This technique does require overwriting the `Makefile` for each of the SPI extensions, but it's quite simple, a short `printf` statement for each.
