### PR TITLE
Replace all Postgres versions in install command

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.15.2"
+version = "0.15.3"
 edition = "2021"
 authors = ["Ian Stanton", "Vinícius Miguel"]
 description = "A package manager for PostgreSQL extensions"
@@ -58,6 +58,7 @@ toml = "0.7.2"
 which = "4.4.0"
 lazy_static = "1.5.0"
 fastrand = "2.1.0"
+regex = "1.11.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.8"

--- a/cli/src/commands/build.rs
+++ b/cli/src/commands/build.rs
@@ -310,13 +310,9 @@ impl SubCommand for BuildCommand {
 }
 
 fn process_install_command(install_command: &str, pg_version: u8) -> Cow<'_, str> {
-    if pg_version == 15 {
-        Cow::Borrowed(install_command)
-    } else {
-        Cow::Owned(
-            install_command
-                .replace("postgresql/15/", &format!("postgresql/{pg_version}/"))
-                .replace("pg15", &format!("pg{pg_version}")),
-        )
-    }
+    // Replace all instances of strings like `postgresql/15` and `pg15`.
+    let re = regex::Regex::new(r"(postgresql/|pg)\d+").unwrap();
+    re.replace_all(install_command, |caps: &regex::Captures| -> String {
+        format!("{}{pg_version}", &caps[1])
+    })
 }


### PR DESCRIPTION
Use regex::Regex::replace_all to replace all instances of strings like `postgresql/15` and `pg15`. Fixes an issue where nothing installed and the trunk ended up with no files and using the version from `Trunk.toml`.