### PR TITLE
Fix Citus `loadable_libraries`

### DIFF
--- a/contrib/citus/Trunk.toml
+++ b/contrib/citus/Trunk.toml
@@ -7,7 +7,7 @@ description = "Distributed PostgreSQL as an extension."
 homepage = "https://www.citusdata.com/"
 documentation = "https://docs.citusdata.com/en/stable/"
 categories = ["tooling_admin"]
-preload_libraries = ["citus"]
+loadable_libraries = [{ library_name = "citus", requires_restart = true }]
 
 [dependencies]
 apt = ["libpq5", "openssl", "libc6", "liblz4-1", "libzstd1", "libssl3", "libcurl4"]


### PR DESCRIPTION
The latest publication of `citus` is missing the `loadable_libraries` section, which is necessary for handling installation in Tembo Cloud and tests in components like `tembo-operator`. 

It's likely that the value was updated manually in the past and the TOML was never updated. This PR updates the TOML with the correct value.