### PR TITLE
Validate extension files

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pg-trunk"
-version = "0.15.2"
+version = "0.15.3"
 edition = "2021"
-authors = ["Ian Stanton", "Vinícius Miguel"]
+authors = ["Ian Stanton", "Vinícius Miguel", "David E. Wheeler"]
 description = "A package manager for PostgreSQL extensions"
 homepage = "https://pgt.dev"
 license = "Apache-2.0"

--- a/cli/src/v1.rs
+++ b/cli/src/v1.rs
@@ -18,6 +18,7 @@ pub struct Extension {
 pub struct Download {
     pub link: String,
     pub pg_version: u8,
+    #[expect(unused)]
     pub platform: String,
     pub sha256: String,
 }


### PR DESCRIPTION
If the `install_command` is incorrect, Trunk CLI builds the extension with an invalid Trunk archive, silently. This PR aims to alert us of such instances, specially when building from CI