### PR TITLE
Fix configure and install errors

### DIFF
--- a/contrib/earthdistance/Dockerfile
+++ b/contrib/earthdistance/Dockerfile
@@ -19,4 +19,5 @@ RUN apt-get update && apt-get install -y \
 ARG EXTENSION_NAME
 ARG PG_RELEASE
 RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& (cd postgres && ./configure --datarootdir "$(pg_config --sharedir)" --libdir "$(pg_config --pkglibdir)") \
 	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/emaj/Dockerfile
+++ b/contrib/emaj/Dockerfile
@@ -6,4 +6,5 @@ ARG RELEASE=4.5.0
 RUN curl -O https://api.pgxn.org/dist/e-maj/${RELEASE}/e-maj-${RELEASE}.zip \
 	&& unzip e-maj-${RELEASE}.zip \
 	&& cd e-maj-${RELEASE} \
+	&& perl -i -pe 's/#directory/directory/' emaj.control \
 	&& make

--- a/contrib/emaj/Trunk.toml
+++ b/contrib/emaj/Trunk.toml
@@ -14,4 +14,4 @@ apt = ["libstdc++6", "libgcc-s1", "libc6"]
 postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = "cd emaj-4.5.0 && make install"
+install_command = "cd e-maj-4.5.0 && make install"

--- a/contrib/hstore/Dockerfile
+++ b/contrib/hstore/Dockerfile
@@ -19,4 +19,5 @@ RUN apt-get update && apt-get install -y \
 ARG EXTENSION_NAME
 ARG PG_RELEASE
 RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& (cd postgres && ./configure --datarootdir "$(pg_config --sharedir)" --libdir "$(pg_config --pkglibdir)") \
 	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/hstore_plperl/Dockerfile
+++ b/contrib/hstore_plperl/Dockerfile
@@ -21,4 +21,5 @@ RUN apt-get update && apt-get install -y \
 ARG EXTENSION_NAME
 ARG PG_RELEASE
 RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& (cd postgres && ./configure --with-perl --datarootdir "$(pg_config --sharedir)" --libdir "$(pg_config --pkglibdir)") \
 	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/hstore_plperlu/Dockerfile
+++ b/contrib/hstore_plperlu/Dockerfile
@@ -21,4 +21,5 @@ RUN apt-get update && apt-get install -y \
 # ARG EXTENSION_NAME
 ARG PG_RELEASE
 RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& (cd postgres && ./configure --with-perl --datarootdir "$(pg_config --sharedir)" --libdir "$(pg_config --pkglibdir)") \
 	&& make -C postgres/contrib/hstore_plperl USE_PGXS=1

--- a/contrib/vectorscale/Trunk.toml
+++ b/contrib/vectorscale/Trunk.toml
@@ -17,6 +17,5 @@ platform = "linux/amd64"
 dockerfile = "Dockerfile"
 install_command = """
     cd pgvectorscale/pgvectorscale
-    mv target/release/vectorscale-pg17/usr/lib/postgresql/15/lib/* /usr/lib/postgresql/15/lib
-    mv target/release/vectorscale-pg17/usr/share/postgresql/15/extension/* /usr/share/postgresql/15/extension
+    RUSTFLAGS="-C target-feature=+avx2,+fma" cargo pgrx install --release
 """


### PR DESCRIPTION
Configure postgres for extensions that need it, properly install vectorize, and change into the correct directory to install emaj.