### PR TITLE
Update and fix pljava, plrust, a couple others

### DIFF
--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -119,7 +119,7 @@ jobs:
         if: matrix.pg == 15
         shell: bash -e {0}
         run: |
-          for val in pg_cron timescaledb pg_search pg_analytics citus; do
+          for val in pg_cron timescaledb pg_search pg_analytics citus plrust; do
             if [[ "${{ matrix.ext.path }}" == *"$val"* ]]; then
               echo handling shared_preload_libraries for $val
               echo "shared_preload_libraries = '$val'" >> /var/lib/postgresql/data2/postgresql.conf

--- a/contrib/pg_anonymize/Dockerfile
+++ b/contrib/pg_anonymize/Dockerfile
@@ -1,10 +1,13 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/rjuju/pg_anonymize.git
+ARG EXTENSION_NAME
+# ARG EXTENSION_VERSION
+ARG REVISION=692b354
 
-# Build extension
-RUN cd pg_anonymize && \
-    make
+# Clone repository and build the extension.
+RUN git clone https://github.com/rjuju/${EXTENSION_NAME}.git ${RELEASE} \
+	&& cd ${EXTENSION_NAME} \
+    && git checkout ${REVISION} \
+	&& make

--- a/contrib/pg_anonymize/Trunk.toml
+++ b/contrib/pg_anonymize/Trunk.toml
@@ -15,10 +15,4 @@ apt = ["libc6"]
 postgres_version = "15"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_anonymize && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
-
+install_command = "make -C pg_anonymize install"

--- a/contrib/pg_failover_slots/Dockerfile
+++ b/contrib/pg_failover_slots/Dockerfile
@@ -1,17 +1,12 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
-RUN apt-get update && apt-get install -y \
-    libkrb5-dev
+USER root
+RUN apt-get update && apt-get install -y libkrb5-dev
 
-# Clone repository
-RUN git clone https://github.com/EnterpriseDB/pg_failover_slots.git
-
-ARG RELEASE=v1.0.1
-
-RUN cd pg_failover_slots && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/EnterpriseDB/${EXTENSION_NAME}.git \
+	&& make -C ${EXTENSION_NAME}

--- a/contrib/pg_failover_slots/Trunk.toml
+++ b/contrib/pg_failover_slots/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_failover_slots"
-version = "1.0.1"
+version = "1.1.0"
 repository = "https://github.com/EnterpriseDB/pg_failover_slots"
 license = "PostgreSQL"
 description = "PG Failover Slots avoids the need for you to reseed your logical replication tables when a new standby gets promoted to primary."
@@ -13,13 +13,7 @@ preload_libraries = ["pg_failover_slots"]
 apt = ["libc6", "libpq5"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_failover_slots && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
-
+install_command = "make -C pg_failover_slots install"

--- a/contrib/pljava/Dockerfile
+++ b/contrib/pljava/Dockerfile
@@ -1,5 +1,5 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 USER root
 
@@ -10,14 +10,9 @@ RUN apt-get update && apt-get install -y \
     libkrb5-dev \
     libecpg-dev
 
-# Clone repository
-RUN git clone https://github.com/tada/pljava.git
-
-# Set project version
-ARG RELEASE=V1_6_5
-
-# Build extension
-RUN cd pljava && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    mvn clean install
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "V$(perl -E 'print shift =~ s/\./_/gr' "${EXTENSION_VERSION}")" https://github.com/tada/${EXTENSION_NAME}.git \
+	&& cd ${EXTENSION_NAME} \
+    && mvn clean install

--- a/contrib/pljava/Trunk.toml
+++ b/contrib/pljava/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pljava"
-version = "1.6.5"
+version = "1.6.8"
 repository = "https://github.com/tada/pljava"
 license = "BSD-3-Clause"
 description = "Java Procedural Language for PostgreSQL"
@@ -11,16 +11,7 @@ categories = ["procedural_languages"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    mkdir /app/pljava/pljava-packaging/target/unpacked
-    cd /app/pljava/pljava-packaging/target/unpacked
-    jar -xf /app/pljava/pljava-packaging/target/pljava-pg15.jar
-    set -x
-    mv /app/pljava/pljava-packaging/target/unpacked/pljava/sharedir/pljava/* /usr/share/postgresql/15/extension
-    mv /app/pljava/pljava-packaging/target/unpacked/pljava/sharedir/extension/* /usr/share/postgresql/15/extension
-    mv /app/pljava/pljava-so/target/pljava-pgxs/* /usr/lib/postgresql/15/lib
-    """
-
+install_command = "java -jar pljava/pljava-packaging/target/pljava-pg17.jar"

--- a/contrib/plrust/Dockerfile
+++ b/contrib/plrust/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
-FROM quay.io/coredb/pgrx-builder:pg${PG_VERSION}-pgrx0.9.7
-USER root
+ARG PG_VERSION
+FROM quay.io/coredb/pgrx-builder:pg${PG_VERSION}-pgrx0.11.0
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -26,31 +26,21 @@ RUN apt-get update && apt-get install -y \
 	crossbuild-essential-amd64 \
 	gcc-aarch64-linux-gnu
 
-# Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+ARG PG_VERSION
 
-# Set default Rust version
-RUN rustup default stable
-
-RUN rustup component add llvm-tools-preview rustc-dev && \
-	rustup target install x86_64-unknown-linux-gnu
-
-# Clone repository
-RUN git clone https://github.com/tcdi/plrust.git
-
-ARG RELEASE=v1.2.3
-
-# Build the extension
-RUN cd plrust && \
-	git fetch origin ${RELEASE} && \
-	git checkout ${RELEASE} && \
-	cd plrustc && \
-	./build.sh && \
-	cd .. && \
- 	mv /app/plrust/build/bin/plrustc /app/plrust/.cargo/bin && \
-	cd /app/plrust/plrust && \
-	PG_VER=15 && \
-	STD_TARGETS="x86_64-postgres-linux-gnu " && \
-	./build && \
- 	cargo pgrx init --pg15 /usr/bin/pg_config && \
-  	cargo pgrx package --features trusted -c /usr/bin/pg_config
+# Install Rust and clone & build the extension.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+	# Set default Rust version
+	&& rustup default stable \
+	&& rustup component add llvm-tools-preview rustc-dev \
+	&& rustup target install x86_64-unknown-linux-gnu \
+	&& git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/tcdi/${EXTENSION_NAME}.git \
+	&& cd ${EXTENSION_NAME} \
+	&& (cd ${EXTENSION_NAME}c && ./build.sh) \
+	&& mv build/bin .cargo \
+	&& cd plrust \
+	&& env PG_VER=${PG_VERSION} STD_TARGETS="x86_64-postgres-linux-gnu " ./build \
+	&& cargo pgrx init --pg${PG_VERSION} /usr/bin/pg_config \
+	&& cargo pgrx package --features trusted -c /usr/bin/pg_config

--- a/contrib/plrust/Trunk.toml
+++ b/contrib/plrust/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "plrust"
-version = "1.2.3"
+version = "1.2.8"
 repository = "https://github.com/tcdi/plrust"
 license = "PostgreSQL"
 description = "A Rust procedural language handler for PostgreSQL."
@@ -16,9 +16,4 @@ apt = ["libc6", "libgcc-s1"]
 postgres_version = "15"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd plrust/
-    mv target/release/plrust-pg15/usr/lib/postgresql/15/lib/* /usr/lib/postgresql/15/lib
-    mv target/release/plrust-pg15/usr/share/postgresql/15/extension/* /usr/share/postgresql/15/extension
-"""
-
+install_command = "cd plrust/plrust && cargo pgrx install --features trusted -c /usr/bin/pg_config"


### PR DESCRIPTION
Rework pg_anonymize and pg_failover_slots after finding they lack control files on pgt.dev. They are shared library extensions, so this makes sense.

But plrust and pljava should have control files. Rework their build scripting to be more efficient and correct, using the tools the ship with that handle installation.