### PR TITLE
Update hypopg, icu_ext, ip4r, jdbc_fdw

### DIFF
--- a/contrib/hypopg/Dockerfile
+++ b/contrib/hypopg/Dockerfile
@@ -1,12 +1,9 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/HypoPG/hypopg.git
-
-ARG RELEASE=1.4.0
-
-RUN cd hypopg && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "${EXTENSION_VERSION}" https://github.com/HypoPG/${EXTENSION_NAME}.git \
+    && cd ${EXTENSION_NAME} \
+    && make

--- a/contrib/hypopg/Trunk.toml
+++ b/contrib/hypopg/Trunk.toml
@@ -1,23 +1,17 @@
 [extension]
 name = "hypopg"
-version = "1.4.0"
+version = "1.4.1"
 repository = "https://github.com/HypoPG/hypopg"
 license = "PostgreSQL"
 description = "Hypothetical Indexes for PostgreSQL."
 documentation = "https://hypopg.readthedocs.io/"
 categories = ["index_table_optimizations"]
 
-
 [dependencies]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd hypopg && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C hypopg install"

--- a/contrib/icu_ext/Dockerfile
+++ b/contrib/icu_ext/Dockerfile
@@ -1,15 +1,10 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
-# Clone repository
-RUN git clone https://github.com/dverite/icu_ext.git
-
-ARG RELEASE=v1.8.0
-
-# Build extension
-RUN cd icu_ext && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/dverite/${EXTENSION_NAME}.git \
+    && cd ${EXTENSION_NAME} \
+    && make

--- a/contrib/icu_ext/Trunk.toml
+++ b/contrib/icu_ext/Trunk.toml
@@ -1,18 +1,13 @@
 [extension]
 name = "icu_ext"
-version = "1.8.0"
+version = "1.9.0"
 repository = "https://github.com/dverite/icu_ext"
 license = "PostgreSQL"
 description = "Access ICU functions."
 categories = ["data_transformations"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd icu_ext && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C icu_ext install"

--- a/contrib/index_advisor/Dockerfile
+++ b/contrib/index_advisor/Dockerfile
@@ -1,15 +1,10 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/supabase/index_advisor.git
-
-# Set project version
-ARG RELEASE=v0.2.0
-
-# Build extension
-RUN cd index_advisor && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/supabase/${EXTENSION_NAME}.git \
+    && cd ${EXTENSION_NAME} \
+    && make

--- a/contrib/index_advisor/Trunk.toml
+++ b/contrib/index_advisor/Trunk.toml
@@ -11,12 +11,7 @@ categories = ["index_table_optimizations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd index_advisor && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C index_advisor install"

--- a/contrib/ip4r/Dockerfile
+++ b/contrib/ip4r/Dockerfile
@@ -1,11 +1,9 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-ARG RELEASE=2.4.1
 
-# Clone repository
-RUN git clone https://github.com/RhodiumToad/ip4r.git
-
-RUN cd ip4r && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "${EXTENSION_VERSION}" https://github.com/RhodiumToad/${EXTENSION_NAME}.git \
+    && cd ${EXTENSION_NAME} \
+    && make

--- a/contrib/ip4r/Trunk.toml
+++ b/contrib/ip4r/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "ip4r"
-version = "2.4.0"
+version = "2.4.2"
 repository = "https://github.com/RhodiumToad/ip4r"
 license = "PostgreSQL"
 description = "IPv4/v6 and IPv4/v6 range index type for PostgreSQL."
@@ -10,7 +10,7 @@ categories = ["data_transformations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = "cd ip4r && make install"
+install_command = "make -C ip4r install"

--- a/contrib/jdbc_fdw/Dockerfile
+++ b/contrib/jdbc_fdw/Dockerfile
@@ -1,12 +1,9 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
-
-
-
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 		build-essential \
 		libreadline-dev \
@@ -20,24 +17,13 @@ RUN apt-get update && apt-get install -y \
 		ccache \
         openjdk-11-jdk
 
-RUN mkdir -p /usr/lib64 && ln -s /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so /usr/lib64/libjvm.so
-# Clone postgres repository
-ARG PG_RELEASE=REL_15_3
-RUN git clone  --depth 1 --branch ${PG_RELEASE} https://github.com/postgres/postgres.git
-RUN cd postgres && \
-	./configure
-
-#Clone jdbc repository
-ARG JDBC_RELEASE=v0.3.1
-RUN cd postgres/contrib && \
-    git clone --depth 1 --branch ${JDBC_RELEASE} https://github.com/pgspider/jdbc_fdw.git
-
-
-RUN cd postgres/contrib/jdbc_fdw && \
-    make clean && \
-    make
-
-    
-
-
-
+# Clone and build the extension.
+ARG EXTENSION_NAME
+# ARG EXTENSION_VERSION
+ARG RELEASE=v0.4.0
+RUN git clone --depth 1 --branch "${RELEASE}" https://github.com/pgspider/${EXTENSION_NAME}.git \
+    && cd ${EXTENSION_NAME} \
+	&& mkdir -p /usr/lib64 \
+	&& ln -s $(find /usr/lib/jvm/ -name 'libjvm.so') /usr/lib64/ \
+	&& make clean USE_PGXS=1 \
+    && make USE_PGXS=1

--- a/contrib/jdbc_fdw/Trunk.toml
+++ b/contrib/jdbc_fdw/Trunk.toml
@@ -14,9 +14,4 @@ apt = ["libpq5", "libc6", "openjdk-18-jre-headless"]
 postgres_version = "15"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/jdbc_fdw && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C jdbc_fdw install USE_PGXS=1"

--- a/contrib/kafka_fdw/Dockerfile
+++ b/contrib/kafka_fdw/Dockerfile
@@ -1,16 +1,15 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
-RUN apt-get update && apt-get install -y \
-    librdkafka-dev \
-    zlib1g-dev
+USER root
+RUN apt-get update && apt-get install -y  librdkafka-dev zlib1g-dev
 
-# Clone repository
-RUN git clone https://github.com/adjust/kafka_fdw.git
-
-# Build extension
-RUN cd kafka_fdw && \
-    make
+ARG EXTENSION_NAME
+# ARG EXTENSION_VERSION
+ARG RELEASE=c73ab18
+RUN git clone https://github.com/adjust/${EXTENSION_NAME}.git \
+    && cd ${EXTENSION_NAME} \
+    && git checkout ${RELEASE} \
+    && make

--- a/contrib/kafka_fdw/Trunk.toml
+++ b/contrib/kafka_fdw/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["connectors"]
 apt = ["librdkafka1", "libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd kafka_fdw && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C kafka_fdw install"

--- a/contrib/lower_quantile/Dockerfile
+++ b/contrib/lower_quantile/Dockerfile
@@ -1,8 +1,10 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/tvondra/lower_quantile.git
-
-RUN cd lower_quantile && \
-    make
+ARG EXTENSION_NAME
+# ARG EXTENSION_VERSION
+ARG RELEASE=12c48a7
+RUN git clone https://github.com/tvondra/${EXTENSION_NAME}.git \
+    && cd ${EXTENSION_NAME} \
+    && git checkout ${RELEASE} \
+    && make

--- a/contrib/lower_quantile/Trunk.toml
+++ b/contrib/lower_quantile/Trunk.toml
@@ -14,9 +14,4 @@ apt = ["libc6"]
 postgres_version = "15"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd lower_quantile && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C lower_quantile install"

--- a/contrib/meta/Dockerfile
+++ b/contrib/meta/Dockerfile
@@ -1,15 +1,12 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/aquameta/meta.git
-
-# Set project version
-ARG RELEASE=v0.3.0
-
-# Build extension
-RUN cd meta && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/aquameta/${EXTENSION_NAME}.git \
+    && cd ${EXTENSION_NAME} \
+    # https://github.com/aquameta/meta/pull/39
+    && printf "requires = 'hstore'\n" >> ${EXTENSION_NAME}.control \
+    && make

--- a/contrib/meta/Trunk.toml
+++ b/contrib/meta/Trunk.toml
@@ -8,12 +8,7 @@ documentation = "https://github.com/aquameta/meta"
 categories = ["tooling_admin"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd meta && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C meta install"


### PR DESCRIPTION
Simplify the build scripting for these extensions:

*   hypopg
*   icu_ext
*   index_advisor
*   ip4r
*   jdbc_fdw
*   kafka_fdw
*   lower_quantile
*   meta

Upgrade these extensions to versions:

*   hypopg 1.4.1
*   icu_ext 1.9.0
*   ip4r 2.4.2
*   jdbc_fdw v0.4.0

Pin these extensions to specific commits rather than the main branch:

*   kafka_fdw
*   lower_quantile