### PR TITLE
Update 10 extensions for Postgres 17

### DIFF
--- a/contrib/jdbc_fdw/Trunk.toml
+++ b/contrib/jdbc_fdw/Trunk.toml
@@ -11,7 +11,7 @@ categories = ["connectors"]
 apt = ["libpq5", "libc6", "openjdk-18-jre-headless"]
 
 [build]
-postgres_version = "15"
+postgres_version = "16"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
 install_command = "make -C jdbc_fdw install USE_PGXS=1"

--- a/contrib/kafka_fdw/Trunk.toml
+++ b/contrib/kafka_fdw/Trunk.toml
@@ -12,7 +12,7 @@ categories = ["connectors"]
 apt = ["librdkafka1", "libc6"]
 
 [build]
-postgres_version = "17"
+postgres_version = "16"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
 install_command = "make -C kafka_fdw install"

--- a/contrib/meta_triggers/Trunk.toml
+++ b/contrib/meta_triggers/Trunk.toml
@@ -8,7 +8,7 @@ documentation = "https://github.com/aquameta/meta_triggers"
 categories = ["tooling_admin"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
 install_command = "make -C meta_triggers install"

--- a/contrib/mobilitydb/Dockerfile
+++ b/contrib/mobilitydb/Dockerfile
@@ -1,7 +1,9 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
+# Set up iamge to copy trunk from.
+FROM quay.io/tembo/trunk-test-tembo:f3b2a28-pg15 AS trunk
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
+USER root
 RUN apt-get update && \
     apt-get install -y \
     libgeos-dev \
@@ -12,25 +14,15 @@ RUN apt-get update && \
     libgsl-dev \
     libjson-c-dev
 
-# Download and build PostGIS
-RUN wget https://download.osgeo.org/postgis/source/postgis-3.4.0.tar.gz && \
-    tar xvf postgis-3.4.0.tar.gz && \
-    cd postgis-3.4.0 && \
-    ./configure && \
-    make && \
-    make install
+# Install trunk
+COPY --from=trunk /usr/bin/trunk /usr/bin/trunk
 
-# Clone repository
-RUN git clone https://github.com/MobilityDB/MobilityDB
-
-# Set project version
-ARG RELEASE=v1.1.0rc1
-
-# Build extension
-RUN cd MobilityDB && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    mkdir build && \
-    cd build && \
-    cmake .. && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN trunk install postgis \
+    && git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/${EXTENSION_NAME}/${EXTENSION_NAME}.git \
+    && mkdir -p ${EXTENSION_NAME}/build \
+    && cd ${EXTENSION_NAME}/build \
+    && cmake .. \
+    && make

--- a/contrib/mobilitydb/Trunk.toml
+++ b/contrib/mobilitydb/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "mobilitydb"
-version = "1.1.0"
+version = "1.2.0"
 repository = "https://github.com/MobilityDB/MobilityDB"
 license = "PostgreSQL"
 description = "Geospatial trajectory data management."
@@ -10,12 +10,10 @@ categories = ["data_transformations"]
 loadable_libraries = [{ library_name = "postgis-3", requires_restart = true }]
 
 [dependencies]
- apt = ["libc6", "libgsl-dev"]
+apt = ["libc6", "libgsl-dev"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd MobilityDB/build && make install
-"""
+install_command = "make -C mobilitydb/build install"

--- a/contrib/multicorn/Dockerfile
+++ b/contrib/multicorn/Dockerfile
@@ -1,9 +1,9 @@
 # Set the PostgreSQL version
-ARG PG_VERSION=17
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
     build-essential \
     libreadline-dev \
@@ -22,19 +22,11 @@ RUN apt-get update && apt-get install -y \
     python3-pip && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-# Use argument to specify PostgreSQL release
-ARG PG_RELEASE=REL_17_2
-
-# Configure and build PostgreSQL
-RUN cd postgres && \
-    git fetch origin ${PG_RELEASE} && \
-    git checkout ${PG_RELEASE} && \
-    ./configure && \
-    cd contrib && \
-    wget https://github.com/pgsql-io/multicorn2/archive/refs/tags/v3.0.tar.gz && \
-    tar -xvf v3.0.tar.gz && \
-    cd multicorn2-3.0 && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN RELEASE="$(perl -e 'print shift =~ s/[.]0$//r' "${EXTENSION_VERSION}")" \
+    && wget "https://github.com/pgsql-io/${EXTENSION_NAME}2/archive/refs/tags/v${RELEASE}.tar.gz" \
+    && tar -xvf "v${RELEASE}.tar.gz" \
+    && mv "${EXTENSION_NAME}2-${RELEASE}" "${EXTENSION_NAME}" \
+    && make -C "${EXTENSION_NAME}"

--- a/contrib/multicorn/Trunk.toml
+++ b/contrib/multicorn/Trunk.toml
@@ -12,9 +12,4 @@ categories = ["connectors"]
 postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/multicorn2-3.0 && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C multicorn install"

--- a/contrib/ora_migrator/Dockerfile
+++ b/contrib/ora_migrator/Dockerfile
@@ -1,15 +1,9 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/cybertec-postgresql/ora_migrator.git
-
-# Set project version
-ARG RELEASE=RELEASE_1_0_0
-
-# Build extension
-RUN cd ora_migrator && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "RELEASE_$(perl -E 'print shift =~ s/\./_/gr' "${EXTENSION_VERSION}")" https://github.com/cybertec-postgresql/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/ora_migrator/Trunk.toml
+++ b/contrib/ora_migrator/Trunk.toml
@@ -8,12 +8,7 @@ documentation = "https://github.com/cybertec-postgresql/ora_migrator"
 categories = ["connectors"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd ora_migrator && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C ora_migrator install"

--- a/contrib/oracle_fdw/Dockerfile
+++ b/contrib/oracle_fdw/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
-FROM quay.io/coredb/c-builder:pg${PG_VERSION} as build
-USER root
+ARG PG_VERSION
+FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	build-essential \
 	libreadline-dev \
@@ -17,32 +17,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	ccache \
 	libaio1 \
 	unzip \
-	wget && \
-	rm -rf /var/lib/apt/lists/*
+	wget \
+	&& rm -rf /var/lib/apt/lists/* \
+	# Download and unpack Oracle Instant Client (Basic and SDK)
+	&& mkdir /opt/oracle \
+    && wget -q https://download.oracle.com/otn_software/linux/instantclient/19800/instantclient-basiclite-linux.x64-19.8.0.0.0dbru.zip \
+    && wget -q https://download.oracle.com/otn_software/linux/instantclient/19800/instantclient-sdk-linux.x64-19.8.0.0.0dbru.zip \
+    && unzip instantclient-basiclite-linux.x64-19.8.0.0.0dbru.zip -d /opt/oracle \
+    && unzip instantclient-sdk-linux.x64-19.8.0.0.0dbru.zip -d /opt/oracle \
+    && rm instantclient-basiclite-linux.x64-19.8.0.0.0dbru.zip instantclient-sdk-linux.x64-19.8.0.0.0dbru.zip \
+    && echo /opt/oracle/instantclient_19_8 > /etc/ld.so.conf.d/oracle-instantclient.conf \
+    && ldconfig \
+    && ln -sf /opt/oracle/instantclient_19_8/libclntsh.so.19.1 /opt/oracle/instantclient_19_8/libclntsh.so
 
-# Download and unpack Oracle Instant Client (Basic and SDK)
-RUN mkdir /opt/oracle && \
-    wget -q https://download.oracle.com/otn_software/linux/instantclient/19800/instantclient-basiclite-linux.x64-19.8.0.0.0dbru.zip && \
-    wget -q https://download.oracle.com/otn_software/linux/instantclient/19800/instantclient-sdk-linux.x64-19.8.0.0.0dbru.zip && \
-    unzip instantclient-basiclite-linux.x64-19.8.0.0.0dbru.zip -d /opt/oracle && \
-    unzip instantclient-sdk-linux.x64-19.8.0.0.0dbru.zip -d /opt/oracle && \
-    rm instantclient-basiclite-linux.x64-19.8.0.0.0dbru.zip instantclient-sdk-linux.x64-19.8.0.0.0dbru.zip && \
-    echo /opt/oracle/instantclient_19_8 > /etc/ld.so.conf.d/oracle-instantclient.conf && \
-    ldconfig && \
-    ln -sf /opt/oracle/instantclient_19_8/libclntsh.so.19.1 /opt/oracle/instantclient_19_8/libclntsh.so
-
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-# Build extension
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure --without-ldap && \
-	cd contrib && \
-	git clone https://github.com/laurenz/oracle_fdw.git && \
-	cd oracle_fdw && \
-	make ORACLE_HOME=/opt/oracle/instantclient_19_8 USE_PGXS=1
-
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+ARG RELEASE=ORACLE_FDW_2_7_0
+RUN git clone --depth 1 --branch "${RELEASE}" https://github.com/laurenz/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME} ORACLE_HOME=/opt/oracle/instantclient_19_8 USE_PGXS=1

--- a/contrib/oracle_fdw/Trunk.toml
+++ b/contrib/oracle_fdw/Trunk.toml
@@ -11,12 +11,7 @@ categories = ["connectors"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/oracle_fdw && make USE_PGXS=1 install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C oracle_fdw install USE_PGXS=1"

--- a/contrib/orafce/Dockerfile
+++ b/contrib/orafce/Dockerfile
@@ -1,12 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/orafce/orafce.git
-
-ARG RELEASE=VERSION_4_4_0
-
-RUN cd orafce && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "VERSION_$(perl -E 'print shift =~ s/\./_/gr' "${EXTENSION_VERSION}")" https://github.com/${EXTENSION_NAME}/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/orafce/Trunk.toml
+++ b/contrib/orafce/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "orafce"
-version = "4.4.0"
+version = "4.14.0"
 repository = "https://github.com/orafce/orafce"
 license = "0BSD"
 description = "Functions and operators that emulate a subset of functions and packages from the Oracle RDBMS."
@@ -14,9 +14,4 @@ apt = ["libc6"]
 postgres_version = "15"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd orafce && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C orafce install"

--- a/contrib/periods/Dockerfile
+++ b/contrib/periods/Dockerfile
@@ -1,12 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/xocolatl/periods.git
-
-ARG RELEASE=v1.2.2
-
-RUN cd periods && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/xocolatl/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/periods/Trunk.toml
+++ b/contrib/periods/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "periods"
-version = "1.2.0"
+version = "1.2.2"
 repository = "https://github.com/xocolatl/periods"
 license = "PostgreSQL"
 description = "This extension recreates the behavior defined in SQL:2016 (originally in SQL:2011) around periods and tables with SYSTEM VERSIONING."
@@ -11,12 +11,7 @@ categories = ["data_transformations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd periods && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C periods install"

--- a/contrib/permuteseq/Dockerfile
+++ b/contrib/permuteseq/Dockerfile
@@ -1,16 +1,9 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
-# Clone repository
-RUN git clone https://github.com/dverite/permuteseq.git
-
-ARG RELEASE=v1.2.2
-
-# Build extension
-RUN cd permuteseq && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
-
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/dverite/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/permuteseq/Trunk.toml
+++ b/contrib/permuteseq/Trunk.toml
@@ -7,12 +7,7 @@ description = "Pseudo-randomly permute sequences with a format-preserving encryp
 categories = ["analytics"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd permuteseq && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C permuteseq install"

--- a/contrib/pg_base36/Dockerfile
+++ b/contrib/pg_base36/Dockerfile
@@ -1,0 +1,11 @@
+ARG PG_VERSION
+FROM quay.io/coredb/c-builder:pg${PG_VERSION}
+
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+
+# Extension build dependencies
+RUN curl -O https://api.pgxn.org/dist/base36/${EXTENSION_VERSION}/base36-${EXTENSION_VERSION}.zip \
+    && unzip base36-${EXTENSION_VERSION}.zip \
+    && cd base36-${EXTENSION_VERSION} && make
+WORKDIR /app/base36-${EXTENSION_VERSION}

--- a/contrib/pg_base36/Trunk.toml
+++ b/contrib/pg_base36/Trunk.toml
@@ -1,0 +1,13 @@
+[extension]
+name = "pg_base36"
+version = "1.1.1"
+repository = "https://github.com/adjust/pg-base36"
+license = "MIT"
+description = "A Base36 extension for PostgreSQL."
+categories = ["data_transformations"]
+
+[build]
+postgres_version = "17"
+platform = "linux/amd64"
+dockerfile = "Dockerfile"
+install_command = "make install"

--- a/contrib/pg_base62/Dockerfile
+++ b/contrib/pg_base62/Dockerfile
@@ -1,0 +1,11 @@
+ARG PG_VERSION
+FROM quay.io/coredb/c-builder:pg${PG_VERSION}
+
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+
+# Extension build dependencies
+RUN curl -O https://api.pgxn.org/dist/base62/${EXTENSION_VERSION}/base62-${EXTENSION_VERSION}.zip \
+    && unzip base62-${EXTENSION_VERSION}.zip \
+    && cd base62-${EXTENSION_VERSION} && make
+WORKDIR /app/base62-${EXTENSION_VERSION}

--- a/contrib/pg_base62/Trunk.toml
+++ b/contrib/pg_base62/Trunk.toml
@@ -1,0 +1,13 @@
+[extension]
+name = "pg_base62"
+version = "0.0.1"
+repository = "https://github.com/adjust/pg-base62"
+license = "MIT"
+description = "A Base62 extension for PostgreSQL."
+categories = ["data_transformations"]
+
+[build]
+postgres_version = "17"
+platform = "linux/amd64"
+dockerfile = "Dockerfile"
+install_command = "make install"

--- a/contrib/pg_bigm/Dockerfile
+++ b/contrib/pg_bigm/Dockerfile
@@ -1,35 +1,9 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
-# Extension build dependencies
-RUN apt-get update && apt-get install -y \
-	build-essential \
-	libreadline-dev \
-	zlib1g-dev \
-	flex bison \
-	libxml2-dev \
-	libxslt-dev \
-	libssl-dev \
-	libxml2-utils \
-	xsltproc \
-	ccache
-
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-
-ARG PG_RELEASE=REL_15_3
-ARG RELEASE=v1.2-20200228
-
-# Build extension
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib && \
-        git clone https://github.com/pgbigm/pg_bigm.git && \
-	cd pg_bigm && \
-        git fetch origin ${RELEASE} && \
-        git checkout ${RELEASE} && \
-	make USE_PGXS=1
+# Clone and build the extension.
+ARG EXTENSION_NAME
+# ARG EXTENSION_VERSION
+ARG RELEASE=v1.2-20240606
+RUN git clone --depth 1 --branch "${RELEASE}" https://github.com/pgbigm/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/pg_bigm/Trunk.toml
+++ b/contrib/pg_bigm/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["index_table_optimizations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/pg_bigm && make USE_PGXS=1 install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pg_bigm USE_PGXS=1 install"


### PR DESCRIPTION
Simplify the build scripting for these extensions

*   mobilitydb
*   multicorn
*   ora_migrator
*   oracle_fdw
*   orafce
*   periods
*   permuteseq
*   pg_bigm

Add these extensions (previously released manually):

*   pg_base36
*   pg_base62

Upgrade these extensions:

*   mobilitydb v1.2.0
*   orafce v4.14.0
*   periods v1.2.2
*   pg_base36 v1.1.1