### PR TITLE
Update six extensions for Postgres 17

### DIFF
--- a/contrib/pg_currency/Dockerfile
+++ b/contrib/pg_currency/Dockerfile
@@ -1,10 +1,11 @@
-# Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/adjust/pg-currency.git
+# ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
 
-# Build extension
-RUN cd pg-currency && \
-    make
+# Extension build dependencies
+RUN curl -O https://api.pgxn.org/dist/currency/${EXTENSION_VERSION}/currency-${EXTENSION_VERSION}.zip \
+    && unzip currency-${EXTENSION_VERSION}.zip \
+    && cd currency-${EXTENSION_VERSION} && make
+WORKDIR /app/currency-${EXTENSION_VERSION}

--- a/contrib/pg_currency/Trunk.toml
+++ b/contrib/pg_currency/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_currency"
-version = "0.0.3"
+version = "0.0.4"
 repository = "https://github.com/adjust/pg-currency"
 license = "MIT"
 description = "1 Byte Currency ISO type for PostgreSQL."
@@ -12,12 +12,7 @@ categories = ["data_transformations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg-currency && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make install"

--- a/contrib/pg_dbms_job/Dockerfile
+++ b/contrib/pg_dbms_job/Dockerfile
@@ -1,12 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/MigOpsRepos/pg_dbms_job.git
-
-ARG RELEASE=v1.5
-
-RUN cd pg_dbms_job && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v$(perl -E 'print shift =~ s/[.]0$//gr' "${EXTENSION_VERSION}")" https://github.com/MigOpsRepos/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pg_dbms_job/Trunk.toml
+++ b/contrib/pg_dbms_job/Trunk.toml
@@ -8,12 +8,7 @@ documentation = "https://github.com/MigOpsRepos/pg_dbms_job"
 categories = ["orchestration"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_dbms_job && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pg_dbms_job install"

--- a/contrib/pg_dirtyread/Dockerfile
+++ b/contrib/pg_dirtyread/Dockerfile
@@ -1,12 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/df7cb/pg_dirtyread.git
-
-ARG RELEASE=2.6
-
-RUN cd pg_dirtyread && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "$(perl -E 'print shift =~ s/[.]0$//gr' "${EXTENSION_VERSION}")" https://github.com/df7cb/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pg_dirtyread/Trunk.toml
+++ b/contrib/pg_dirtyread/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_dirtyread"
-version = "2.6.0"
+version = "2.7.0"
 repository = "https://github.com/df7cb/pg_dirtyread"
 license = "PostgreSQL"
 description = "Read dead but unvacuumed tuples from a PostgreSQL relation."
@@ -12,12 +12,7 @@ categories = ["search"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_dirtyread && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pg_dirtyread install"

--- a/contrib/pg_extra_time/Dockerfile
+++ b/contrib/pg_extra_time/Dockerfile
@@ -1,16 +1,11 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION=
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
-# Clone repository
-RUN git clone https://github.com/bigsmoke/pg_extra_time.git
-
-ARG RELEASE=v1.1.0
-
-# Build extension
-RUN cd pg_extra_time && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
-
+# Download and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN curl -O https://api.pgxn.org/dist/${EXTENSION_NAME}/${EXTENSION_VERSION}/${EXTENSION_NAME}-${EXTENSION_VERSION}.zip \
+    && unzip ${EXTENSION_NAME}-${EXTENSION_VERSION}.zip \
+    && cd ${EXTENSION_NAME}-${EXTENSION_VERSION} && make
+WORKDIR /app/${EXTENSION_NAME}-${EXTENSION_VERSION}

--- a/contrib/pg_extra_time/Trunk.toml
+++ b/contrib/pg_extra_time/Trunk.toml
@@ -1,18 +1,13 @@
 [extension]
 name = "pg_extra_time"
-version = "1.1.0"
+version = "1.1.2"
 repository = "https://github.com/bigsmoke/pg_extra_time"
 license = "PostgreSQL"
 description = "Additional date time functions."
 categories = ["data_transformations"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_extra_time && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make install"

--- a/contrib/pg_financial/Dockerfile
+++ b/contrib/pg_financial/Dockerfile
@@ -1,15 +1,9 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/intgr/pg_financial.git
-
-# Set project version
-ARG RELEASE=v1.0.1
-
-# Build extension
-RUN cd pg_financial && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/intgr/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pg_financial/Trunk.toml
+++ b/contrib/pg_financial/Trunk.toml
@@ -11,12 +11,7 @@ categories = ["analytics"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_financial && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pg_financial install"

--- a/contrib/pg_hashids/Dockerfile
+++ b/contrib/pg_hashids/Dockerfile
@@ -1,11 +1,7 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-ARG RELEASE=v1.2.1
 
-# Clone repository
-RUN git clone https://github.com/iCyberon/pg_hashids.git
-
-RUN cd pg_hashids && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/iCyberon/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pg_hashids/Trunk.toml
+++ b/contrib/pg_hashids/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_hashids"
-version = "1.3.0"
+version = "1.2.1"
 repository = "https://github.com/iCyberon/pg_hashids"
 license = "MIT"
 description = "Hashids is a small open-source library that generates short, unique, non-sequential ids from numbers."
@@ -10,7 +10,7 @@ categories = ["data_transformations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = "cd pg_hashids && make install"
+install_command = "make -C pg_hashids install"


### PR DESCRIPTION
Update the build scripting steps and default Postgres build for these extensions:

*   pg_currency
*   pg_dbms_job
*   pg_dirtyread
*   pg_extra_time
*   pg_financial
*   pg_hashids

Upgrade these extensions:

*   pg_currency v0.0.4
*   pg_dirtyread v2.7.0
*   pg_extra_time v1.1.2

In addition, record the version of pg_hashids as v1.2.1, to reflect what we have actually been providing.