### PR TITLE
Upate pg_hint_plan on PostgreSQL 14-17

### DIFF
--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -66,6 +66,11 @@ jobs:
       matrix:
         ext: ${{ fromJson(needs.find_directories.outputs.directories).include }}
         pg: [15]
+        exclude:
+          # pg_hint_plabn has separate extensions for each major version
+          - { ext: { name: pg_hint_plan14 } }
+          - { ext: { name: pg_hint_plan16 } }
+          - { ext: { name: pg_hint_plan17 } }
     steps:
       - uses: actions/checkout@v4
       - name: Install system dependencies
@@ -92,6 +97,24 @@ jobs:
       matrix:
         ext: ${{ fromJson(needs.find_directories.outputs.directories).include }}
         pg: [17, 16, 15, 14]
+        exclude:
+          - { pg: 17, ext: { name: adminpack      } } # Removed from Postgres 17
+          - { pg: 17, ext: { name: old_snapshot   } } # Removed from Postgres 17
+          - { pg: 17, ext: { name: pg_lakehouse   } } # Renamed pg_analytics
+          - { pg: 17, ext: { name: pg_sparse      } } # Removed after v0.7.0
+          # pg_hint_plabn has separate extensions for each major version
+          - { pg: 17, ext: { name: pg_hint_plan14 } }
+          - { pg: 17, ext: { name: pg_hint_plan15 } }
+          - { pg: 17, ext: { name: pg_hint_plan16 } }
+          - { pg: 16, ext: { name: pg_hint_plan14 } }
+          - { pg: 16, ext: { name: pg_hint_plan15 } }
+          - { pg: 16, ext: { name: pg_hint_plan17 } }
+          - { pg: 15, ext: { name: pg_hint_plan14 } }
+          - { pg: 15, ext: { name: pg_hint_plan16 } }
+          - { pg: 15, ext: { name: pg_hint_plan17 } }
+          - { pg: 14, ext: { name: pg_hint_plan15 } }
+          - { pg: 14, ext: { name: pg_hint_plan16 } }
+          - { pg: 14, ext: { name: pg_hint_plan17 } }
     env:
       TRUNK_API_TOKEN: ${{ secrets.TRUNK_AUTH_TOKEN }}
       PGHOST: "localhost"

--- a/contrib/pg_hint_plan14/Dockerfile
+++ b/contrib/pg_hint_plan14/Dockerfile
@@ -1,0 +1,7 @@
+ARG PG_VERSION=14
+FROM quay.io/coredb/c-builder:pg${PG_VERSION}
+
+# ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "REL14_$(perl -E 'print shift =~ s/\./_/gr' "${EXTENSION_VERSION}")" https://github.com/ossc-db/pg_hint_plan.git \
+    && make -C pg_hint_plan

--- a/contrib/pg_hint_plan14/Trunk.toml
+++ b/contrib/pg_hint_plan14/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
-name = "pg_hint_plan16"
-version = "1.6.1"
+name = "pg_hint_plan15"
+version = "1.4.3"
 repository = "https://github.com/ossc-db/pg_hint_plan"
 license = "Copyright"
 description = "pg_hint_plan makes it possible to tweak PostgreSQL execution plans."
@@ -12,7 +12,7 @@ categories = ["query_optimizations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "16"
+postgres_version = "14"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
 install_command = "make -C pg_hint_plan install"

--- a/contrib/pg_hint_plan15/Dockerfile
+++ b/contrib/pg_hint_plan15/Dockerfile
@@ -1,0 +1,7 @@
+ARG PG_VERSION=15
+FROM quay.io/coredb/c-builder:pg${PG_VERSION}
+
+# ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "REL15_$(perl -E 'print shift =~ s/\./_/gr' "${EXTENSION_VERSION}")" https://github.com/ossc-db/pg_hint_plan.git \
+    && make -C pg_hint_plan

--- a/contrib/pg_hint_plan15/Trunk.toml
+++ b/contrib/pg_hint_plan15/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
-name = "pg_hint_plan16"
-version = "1.6.1"
+name = "pg_hint_plan15"
+version = "1.5.2"
 repository = "https://github.com/ossc-db/pg_hint_plan"
 license = "Copyright"
 description = "pg_hint_plan makes it possible to tweak PostgreSQL execution plans."
@@ -12,7 +12,7 @@ categories = ["query_optimizations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "16"
+postgres_version = "15"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
 install_command = "make -C pg_hint_plan install"

--- a/contrib/pg_hint_plan16/Dockerfile
+++ b/contrib/pg_hint_plan16/Dockerfile
@@ -1,12 +1,7 @@
-ARG PG_VERSION=15
+ARG PG_VERSION=16
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/ossc-db/pg_hint_plan.git
-
-ARG RELEASE=REL16_1_6_0
-
-RUN cd pg_hint_plan && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "REL16_$(perl -E 'print shift =~ s/\./_/gr' "${EXTENSION_VERSION}")" https://github.com/ossc-db/pg_hint_plan.git \
+    && make -C pg_hint_plan

--- a/contrib/pg_hint_plan17/Dockerfile
+++ b/contrib/pg_hint_plan17/Dockerfile
@@ -1,0 +1,7 @@
+ARG PG_VERSION=16
+FROM quay.io/coredb/c-builder:pg${PG_VERSION}
+
+# ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "REL17_$(perl -E 'print shift =~ s/\./_/gr' "${EXTENSION_VERSION}")" https://github.com/ossc-db/pg_hint_plan.git \
+    && make -C pg_hint_plan

--- a/contrib/pg_hint_plan17/Trunk.toml
+++ b/contrib/pg_hint_plan17/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
-name = "pg_hint_plan16"
-version = "1.6.1"
+name = "pg_hint_plan17"
+version = "1.7.0"
 repository = "https://github.com/ossc-db/pg_hint_plan"
 license = "Copyright"
 description = "pg_hint_plan makes it possible to tweak PostgreSQL execution plans."
@@ -12,7 +12,7 @@ categories = ["query_optimizations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "16"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
 install_command = "make -C pg_hint_plan install"


### PR DESCRIPTION
Include each as a separate extension, since each supports only a single major version of PostgreSQL. Update the extensions workflow to skip incompatible tests and builds, and also for four other extensions that have been removed from Postgres 17.