### PR TITLE
Update 11 more extension for Postgres 17

### DIFF
--- a/contrib/pg_mon/Dockerfile
+++ b/contrib/pg_mon/Dockerfile
@@ -1,12 +1,10 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/RafiaSabih/pg_mon.git
-
-ARG RELEASE=master
-
-RUN cd pg_mon && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+ARG EXTENSION_NAME
+# ARG EXTENSION_VERSION
+ARG RELEASE=d34b316
+RUN git clone https://github.com/RafiaSabih/${EXTENSION_NAME}.git \
+    && cd ${EXTENSION_NAME} \
+    && git checkout ${RELEASE} \
+    && make

--- a/contrib/pg_mon/Trunk.toml
+++ b/contrib/pg_mon/Trunk.toml
@@ -7,7 +7,6 @@ description = "PostgreSQL extension to enhance query monitoring."
 documentation = "https://github.com/RafiaSabih/pg_mon"
 categories = ["query_optimizations"]
 
-
 [dependencies]
 apt = ["libc6"]
 
@@ -15,9 +14,4 @@ apt = ["libc6"]
 postgres_version = "15"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_mon && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pg_mon install"

--- a/contrib/pg_orphaned/Dockerfile
+++ b/contrib/pg_orphaned/Dockerfile
@@ -1,11 +1,11 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
-# Clone repository
-RUN git clone https://github.com/bdrouvot/pg_orphaned.git
-
-# Build extension
-RUN cd pg_orphaned && \
-    make
+ARG EXTENSION_NAME
+# ARG EXTENSION_VERSION
+ARG RELEASE=62a222f
+RUN git clone https://github.com/bdrouvot/${EXTENSION_NAME}.git \
+    && cd ${EXTENSION_NAME} \
+    && git checkout ${RELEASE} \
+    && make

--- a/contrib/pg_orphaned/Trunk.toml
+++ b/contrib/pg_orphaned/Trunk.toml
@@ -8,12 +8,7 @@ documentation = "https://github.com/bdrouvot/pg_orphaned"
 categories = ["data_transformations"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_orphaned && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pg_orphaned install"

--- a/contrib/pg_partman/Dockerfile
+++ b/contrib/pg_partman/Dockerfile
@@ -1,12 +1,10 @@
-ARG PG_VERSION=17
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/pgpartman/pg_partman.git
-
+# Download and build the extension.
+ARG EXTENSION_NAME
 ARG EXTENSION_VERSION
-
-RUN cd pg_partman && \
-    git fetch origin v${EXTENSION_VERSION} && \
-    git checkout v${EXTENSION_VERSION} && \
-    make
+RUN curl -O https://api.pgxn.org/dist/${EXTENSION_NAME}/${EXTENSION_VERSION}/${EXTENSION_NAME}-${EXTENSION_VERSION}.zip \
+    && unzip ${EXTENSION_NAME}-${EXTENSION_VERSION}.zip \
+    && cd ${EXTENSION_NAME}-${EXTENSION_VERSION} && make
+WORKDIR /app/${EXTENSION_NAME}-${EXTENSION_VERSION}

--- a/contrib/pg_partman/Trunk.toml
+++ b/contrib/pg_partman/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_partman"
-version = "5.2.1"
+version = "5.2.2"
 repository = "https://github.com/pgpartman/pg_partman"
 license = "PostgreSQL"
 description = "Extension to manage partitioned tables by time or ID."
@@ -15,9 +15,4 @@ apt = ["libc6"]
 postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_partman && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make install"

--- a/contrib/pg_permissions/Dockerfile
+++ b/contrib/pg_permissions/Dockerfile
@@ -1,15 +1,9 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/cybertec-postgresql/pg_permissions.git
-
-# Set project version
-ARG RELEASE=REL_1_1
-
-# Build extension
-RUN cd pg_permissions && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "REL_$(perl -E 'print shift =~ s/[.]0$//r =~ s/[.]/_/gr' "${EXTENSION_VERSION}")" https://github.com/cybertec-postgresql/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pg_permissions/Trunk.toml
+++ b/contrib/pg_permissions/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_permissions"
-version = "1.1.0"
+version = "1.3.0"
 repository = "https://github.com/cybertec-postgresql/pg_permissions"
 license = "Copyright"
 description = "A simple set of views to see ALL permissions in a PostgreSQL database."
@@ -9,12 +9,7 @@ documentation = "https://github.com/cybertec-postgresql/pg_permissions"
 categories = ["tooling_admin"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_permissions && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pg_permissions install"

--- a/contrib/pg_proctab/Dockerfile
+++ b/contrib/pg_proctab/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -15,17 +15,10 @@ RUN apt-get update && apt-get install -y \
 	xsltproc \
 	ccache
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-# Build extension
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib && \
-	git clone https://gitlab.com/pg_proctab/pg_proctab.git && \
-	cd pg_proctab && \
-	make USE_PGXS=1
+# Download and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN curl -O https://api.pgxn.org/dist/${EXTENSION_NAME}/${EXTENSION_VERSION}/${EXTENSION_NAME}-${EXTENSION_VERSION}.zip \
+    && unzip ${EXTENSION_NAME}-${EXTENSION_VERSION}.zip \
+    && cd ${EXTENSION_NAME}-${EXTENSION_VERSION} && make USE_PGXS=1
+WORKDIR /app/${EXTENSION_NAME}-${EXTENSION_VERSION}

--- a/contrib/pg_proctab/Trunk.toml
+++ b/contrib/pg_proctab/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_proctab"
-version = "0.0.10"
+version = "0.0.12"
 repository = "https://gitlab.com/pg_proctab/pg_proctab"
 license = "Copyright"
 description = "Access operating system process table."
@@ -12,12 +12,7 @@ categories = ["metrics"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/pg_proctab && make USE_PGXS=1 install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make install USE_PGXS=1"

--- a/contrib/pg_quack/Dockerfile
+++ b/contrib/pg_quack/Dockerfile
@@ -1,13 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
-# Clone repository
-RUN git clone https://github.com/hydradatabase/pg_quack.git
-
-ARG RELEASE=v0.0.1
-
-RUN cd pg_quack &&  \
-    git checkout ${RELEASE} &&  \
-    make
-
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/hydradatabase/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pg_quack/Trunk.toml
+++ b/contrib/pg_quack/Trunk.toml
@@ -8,7 +8,6 @@ homepage = "https://www.hydra.so"
 documentation = "https://github.com/hydradatabase/pg_quack"
 categories = ["connectors"]
 
-
 [dependencies]
 apt = ["libc6"]
 
@@ -16,9 +15,4 @@ apt = ["libc6"]
 postgres_version = "15"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_quack && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pg_quack install"

--- a/contrib/pg_qualstats/Dockerfile
+++ b/contrib/pg_qualstats/Dockerfile
@@ -1,15 +1,9 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/powa-team/pg_qualstats.git
-
-# Set project version
-ARG RELEASE=2.0.4
-
-# Build extension
-RUN cd pg_qualstats && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "${EXTENSION_VERSION}" https://github.com/powa-team/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pg_qualstats/Trunk.toml
+++ b/contrib/pg_qualstats/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_qualstats"
-version = "2.0.4"
+version = "2.1.1"
 repository = "https://github.com/powa-team/pg_qualstats"
 license = "Copyright"
 description = "pg_qualstats is a PostgreSQL extension keeping statistics on predicates found in WHERE statements and JOIN clauses."
@@ -13,12 +13,7 @@ preload_libraries = ["pg_qualstats"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_qualstats && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pg_qualstats install"

--- a/contrib/pg_rational/Dockerfile
+++ b/contrib/pg_rational/Dockerfile
@@ -1,15 +1,9 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/begriffs/pg_rational.git
-
-# Set project version
-ARG RELEASE=v0.0.2
-
-# Build extension
-RUN cd pg_rational && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/begriffs/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pg_rational/Trunk.toml
+++ b/contrib/pg_rational/Trunk.toml
@@ -11,12 +11,7 @@ categories = ["analytics"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_rational && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pg_rational install"

--- a/contrib/pg_repack/Dockerfile
+++ b/contrib/pg_repack/Dockerfile
@@ -1,8 +1,8 @@
 ARG PG_VERSION=15
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -17,17 +17,10 @@ RUN apt-get update && apt-get install -y \
 	libzstd-dev \
 	liblz4-dev
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-ARG PG_RELEASE=REL_15_3
-
-# Build extension
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib && \
-	git clone https://github.com/reorg/pg_repack.git && \
-	cd pg_repack && \
-	make USE_PGXS=1
+# Extension build dependencies
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN curl -O https://api.pgxn.org/dist/${EXTENSION_NAME}/${EXTENSION_VERSION}/${EXTENSION_NAME}-${EXTENSION_VERSION}.zip \
+    && unzip ${EXTENSION_NAME}-${EXTENSION_VERSION}.zip \
+    && cd ${EXTENSION_NAME}-${EXTENSION_VERSION} && make
+WORKDIR /app/${EXTENSION_NAME}-${EXTENSION_VERSION}

--- a/contrib/pg_repack/Trunk.toml
+++ b/contrib/pg_repack/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_repack"
-version = "1.4.8"
+version = "1.5.2"
 repository = "https://github.com/reorg/pg_repack"
 license = "BSD-3-Clause"
 description = "pg_repack is a PostgreSQL extension which lets you remove bloat from tables and indexes, and optionally restore the physical order of clustered indexes."
@@ -11,12 +11,7 @@ categories = ["index_table_optimizations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-   cd postgres/contrib/pg_repack && make USE_PGXS=1 install
-   set -x
-   mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-   mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-   """
+install_command = "make install"

--- a/contrib/pg_roaringbitmap/Dockerfile
+++ b/contrib/pg_roaringbitmap/Dockerfile
@@ -1,15 +1,11 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/ChenHuajun/pg_roaringbitmap.git
-
-# Set project version
-ARG RELEASE=v0.5.4
-
-# Build extension
-RUN cd pg_roaringbitmap && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Extension build dependencies
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN curl -O https://api.pgxn.org/dist/${EXTENSION_NAME}/${EXTENSION_VERSION}/${EXTENSION_NAME}-${EXTENSION_VERSION}.zip \
+    && unzip ${EXTENSION_NAME}-${EXTENSION_VERSION}.zip \
+    && cd ${EXTENSION_NAME}-${EXTENSION_VERSION} && make
+WORKDIR /app/${EXTENSION_NAME}-${EXTENSION_VERSION}

--- a/contrib/pg_roaringbitmap/Trunk.toml
+++ b/contrib/pg_roaringbitmap/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_roaringbitmap"
-version = "0.5.0"
+version = "0.5.4"
 repository = "https://github.com/ChenHuajun/pg_roaringbitmap"
 license = "Apache-2.0"
 description = "Support for Roaring Bitmaps."
@@ -11,12 +11,7 @@ categories = ["data_transformations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_roaringbitmap && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make install"

--- a/contrib/pg_savior/Dockerfile
+++ b/contrib/pg_savior/Dockerfile
@@ -1,8 +1,11 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
-# Clone repository
-RUN git clone https://github.com/viggy28/pg_savior
-
-RUN cd pg_savior && make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+# ARG EXTENSION_VERSION
+ARG RELEASE=0b85ec4
+RUN git clone https://github.com/viggy28/${EXTENSION_NAME}.git \
+    && cd ${EXTENSION_NAME} \
+    && git checkout ${RELEASE} \
+    && make

--- a/contrib/pg_savior/Trunk.toml
+++ b/contrib/pg_savior/Trunk.toml
@@ -12,13 +12,7 @@ categories = ["security"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_savior && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
-
+install_command = "make -C pg_savior install"


### PR DESCRIPTION
Update the build scripting for these extensions, downloading from PGXN where possible:

*   pg_mon
*   pg_orphaned
*   pg_partman
*   pg_permissions
*   pg_proctab
*   pg_quack
*   pg_qualstats
*   pg_rational
*   pg_repack
*   pg_roaringbitmap
*   pg_savior

Upgrade these extensions:

*   pg_partman v5.2.2
*   pg_permissions v1.3.0
*   pg_proctab v0.0.12
*   pg_qualstats v2.1.1
*   pg_repack v1.5.2
*   pg_roaringbitmap v0.5.4

Pin these extensions that have no releases or tags to specific commits:

*   pg_mon
*   pg_orphaned
*   pg_savior