### PR TITLE
Update nine more extensions for Postgres 17

### DIFF
--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -142,7 +142,7 @@ jobs:
         if: matrix.pg == 15
         shell: bash -e {0}
         run: |
-          for val in pg_cron timescaledb pg_search pg_analytics citus plrust pg_net; do
+          for val in pg_cron timescaledb pg_search pg_analytics citus plrust pg_net pg_stat_kcache pg_squeeze; do
             if [[ "${{ matrix.ext.path }}" == *"$val"* ]]; then
               echo handling shared_preload_libraries for $val
               echo "shared_preload_libraries = '$val'" >> /var/lib/postgresql/data2/postgresql.conf

--- a/contrib/envvar/Dockerfile
+++ b/contrib/envvar/Dockerfile
@@ -1,10 +1,9 @@
 ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
+# Extension build dependencies
 ARG EXTENSION_NAME
 ARG EXTENSION_VERSION
-
-# Extension build dependencies
 RUN curl -O https://api.pgxn.org/dist/${EXTENSION_NAME}/${EXTENSION_VERSION}/${EXTENSION_NAME}-${EXTENSION_VERSION}.zip \
     && unzip ${EXTENSION_NAME}-${EXTENSION_VERSION}.zip \
     && cd ${EXTENSION_NAME}-${EXTENSION_VERSION} && make

--- a/contrib/pg_semver/Dockerfile
+++ b/contrib/pg_semver/Dockerfile
@@ -1,12 +1,10 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/theory/pg-semver.git
-
-ARG RELEASE=v0.32.1
-
-RUN cd pg-semver && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Extension build dependencies
+# ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN curl -O https://api.pgxn.org/dist/semver/${EXTENSION_VERSION}/semver-${EXTENSION_VERSION}.zip \
+    && unzip semver-${EXTENSION_VERSION}.zip \
+    && cd semver-${EXTENSION_VERSION} && make
+WORKDIR /app/semver-${EXTENSION_VERSION}

--- a/contrib/pg_semver/Trunk.toml
+++ b/contrib/pg_semver/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_semver"
-version = "0.32.1"
+version = "0.40.0"
 repository = "https://github.com/theory/pg-semver"
 license = "PostgreSQL"
 description = "A semantic version data type for PostgreSQL."
@@ -11,12 +11,7 @@ categories = ["data_transformations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg-semver && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make install"

--- a/contrib/pg_show_plans/Dockerfile
+++ b/contrib/pg_show_plans/Dockerfile
@@ -1,20 +1,9 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
-# Extension build dependencies
-RUN apt-get update && apt-get install -y \
-    cmake
-
-# Clone repository
-RUN git clone https://github.com/cybertec-postgresql/pg_show_plans.git
-
-# Set project version
-ARG RELEASE=v2.1.0
-
-# Build extension
-RUN cd pg_show_plans && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/cybertec-postgresql/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pg_show_plans/Trunk.toml
+++ b/contrib/pg_show_plans/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_show_plans"
-version = "2.1.0"
+version = "2.1.2"
 repository = "https://github.com/cybertec-postgresql/pg_show_plans"
 license = "PostgreSQL"
 description = "Show query plans of all currently running SQL statements."
@@ -12,12 +12,7 @@ loadable_libraries = [{ library_name = "pg_show_plans", requires_restart = true 
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_show_plans && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pg_show_plans install"

--- a/contrib/pg_similarity/Dockerfile
+++ b/contrib/pg_similarity/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/eulerto/pg_similarity.git
-
-RUN cd pg_similarity && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "pg_similarity_$(perl -E 'print shift =~ s/[.]0$//r =~ s/[.]/_/gr' "${EXTENSION_VERSION}")" https://github.com/eulerto/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/pg_similarity/Trunk.toml
+++ b/contrib/pg_similarity/Trunk.toml
@@ -11,12 +11,7 @@ categories = ["search"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_similarity && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pg_similarity USE_PGXS=1 install"

--- a/contrib/pg_smtp_client/Dockerfile
+++ b/contrib/pg_smtp_client/Dockerfile
@@ -1,24 +1,14 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/pgrx-builder:pg${PG_VERSION}-pgrx0.12.7
+
+ARG PG_VERSION
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+
 USER root
-
-ARG RELEASE=v0.2.0
-
-# Extension build dependencies
-RUN apt-get update && apt-get install -y \
-	build-essential
-
-# Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-RUN cargo install cargo-pgrx --version 0.12.7 --locked
-
-# Set default Rust version
-RUN /root/.cargo/bin/rustup default stable
-
-# Clone repository
-RUN git clone --depth 1 --branch ${RELEASE} https://github.com/brianpursley/pg_smtp_client
-
-# Build the extension
-RUN cd pg_smtp_client && \
-    cargo pgrx init --pg15 /usr/bin/pg_config && \
-    cargo pgrx package
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    && /root/.cargo/bin/rustup default stable \
+    && git clone --depth 1 --branch v${EXTENSION_VERSION} https://github.com/brianpursley/${EXTENSION_NAME}.git \
+    && cd ${EXTENSION_NAME} \
+    && cargo pgrx init --pg${PG_VERSION}=/usr/bin/pg_config \
+    && cargo pgrx package

--- a/contrib/pg_smtp_client/Trunk.toml
+++ b/contrib/pg_smtp_client/Trunk.toml
@@ -12,11 +12,7 @@ categories = ["tooling_admin"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_smtp_client/
-    mv target/release/pg_smtp_client-pg15/usr/lib/postgresql/15/lib/* /usr/lib/postgresql/15/lib
-    mv target/release/pg_smtp_client-pg15/usr/share/postgresql/15/extension/* /usr/share/postgresql/15/extension
-"""
+install_command = "cd pg_smtp_client && cargo pgrx install --release"

--- a/contrib/pg_sparse/Dockerfile
+++ b/contrib/pg_sparse/Dockerfile
@@ -1,17 +1,11 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 USER root
 
-ARG RELEASE=v0.4.2
 
-# Clone repository
-RUN git clone https://github.com/paradedb/paradedb.git && \
-	cd paradedb && \
-    git fetch --tags && \
-    git fetch --depth 1 origin tag ${RELEASE} && \
-    git checkout ${RELEASE}
-
-RUN cd paradedb/pg_sparse && \
-    make USE_PGXS=1 OPTFLAGS="" && \
-    make install
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/paradedb/paradedb.git \
+    && make -C paradedb/${EXTENSION_NAME} USE_PGXS=1 OPTFLAGS=""

--- a/contrib/pg_sparse/Trunk.toml
+++ b/contrib/pg_sparse/Trunk.toml
@@ -1,7 +1,7 @@
 [extension]
 name = "pg_sparse"
 version = "0.4.2"
-repository = "https://github.com/paradedb/paradedb/tree/dev/pg_sparse"
+repository = "https://github.com/paradedb/paradedb/tree/v0.6.1/pg_sparse"
 license = "AGPL-3.0"
 description = "Sparse Vector Similarity Search Inside Postgres"
 homepage = "https://www.paradedb.com/"
@@ -12,9 +12,7 @@ categories = ["search"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd paradedb/pg_sparse && make install
-"""
+install_command = "make -C paradedb/pg_sparse install USE_PGXS=1"

--- a/contrib/pg_squeeze/Dockerfile
+++ b/contrib/pg_squeeze/Dockerfile
@@ -1,15 +1,9 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/cybertec-postgresql/pg_squeeze.git
-
-# Set project version
-ARG RELEASE=1.5.2
-
-# Build extension
-RUN cd pg_squeeze && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "REL$(perl -E 'print shift =~ s/\./_/gr' "${EXTENSION_VERSION}")" https://github.com/cybertec-postgresql/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pg_squeeze/Trunk.toml
+++ b/contrib/pg_squeeze/Trunk.toml
@@ -12,12 +12,7 @@ categories = ["index_table_optimizations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_squeeze && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pg_squeeze install"

--- a/contrib/pg_stat_kcache/Dockerfile
+++ b/contrib/pg_stat_kcache/Dockerfile
@@ -1,12 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/powa-team/pg_stat_kcache.git
-
-ARG RELEASE=REL2_2_1
-
-RUN cd pg_stat_kcache && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "REL$(perl -E 'print shift =~ s/\./_/gr' "${EXTENSION_VERSION}")" https://github.com/powa-team/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pg_stat_kcache/Trunk.toml
+++ b/contrib/pg_stat_kcache/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_stat_kcache"
-version = "2.2.1"
+version = "2.3.0"
 repository = "https://github.com/powa-team/pg_stat_kcache"
 license = "PostgreSQL"
 description = "Gathers statistics about real reads and writes done by the filesystem layer."
@@ -13,13 +13,7 @@ preload_libraries = ["pg_stat_kcache"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_stat_kcache && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
-
+install_command = "make -C pg_stat_kcache install"

--- a/contrib/pg_stat_monitor/Dockerfile
+++ b/contrib/pg_stat_monitor/Dockerfile
@@ -1,15 +1,11 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/percona/pg_stat_monitor.git
-
-# Set project version
-ARG RELEASE=2.1.0
-
-# Build extension
-RUN cd pg_stat_monitor && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make USE_PGXS=1
+# Extension build dependencies
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN curl -O https://api.pgxn.org/dist/${EXTENSION_NAME}/${EXTENSION_VERSION}/${EXTENSION_NAME}-${EXTENSION_VERSION}.zip \
+    && unzip ${EXTENSION_NAME}-${EXTENSION_VERSION}.zip \
+    && make -C ${EXTENSION_NAME}-${EXTENSION_VERSION} USE_PGXS=1
+WORKDIR /app/${EXTENSION_NAME}-${EXTENSION_VERSION}

--- a/contrib/pg_stat_monitor/Trunk.toml
+++ b/contrib/pg_stat_monitor/Trunk.toml
@@ -13,12 +13,7 @@ loadable_libraries = [{ library_name = "pg_stat_monitor", requires_restart = tru
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_stat_monitor && make USE_PGXS=1 install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make install USE_PGXS=1"

--- a/contrib/pg_store_plans/Dockerfile
+++ b/contrib/pg_store_plans/Dockerfile
@@ -1,38 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
-# Extension build dependencies
-RUN apt-get update && apt-get install -y \
-	build-essential \
-	libreadline-dev \
-	zlib1g-dev \
-	flex bison \
-	libxml2-dev \
-	libxslt-dev \
-	libssl-dev \
-	libxml2-utils \
-	xsltproc \
-	ccache
-
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-# Use argument to specify PostgreSQL release
-ARG PG_RELEASE=REL_15_3
-
-# Configure and build PostgreSQL
-RUN cd postgres && \
-    git fetch origin ${PG_RELEASE} && \
-    git checkout ${PG_RELEASE} && \
-    ./configure && \
-    cd contrib && \
-    git clone https://github.com/ossc-db/pg_store_plans.git
-
-ARG RELEASE=1.8
-
-# Build extension
-RUN cd postgres/contrib/pg_store_plans && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "$(perl -E 'print shift =~ s/[.]0$//gr' "${EXTENSION_VERSION}")" https://github.com/ossc-db/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/pg_store_plans/Trunk.toml
+++ b/contrib/pg_store_plans/Trunk.toml
@@ -9,12 +9,7 @@ categories = ["metrics"]
 loadable_libraries = [{ library_name = "pg_store_plans", requires_restart = true }]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/pg_store_plans && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pg_store_plans install USE_PGXS=1"


### PR DESCRIPTION
Update the build scripting and default Postgres version for these extensions, building from PGXN where available, and with the latest version where it has changed:

*   pg_semver v0.40.0
*   pg_show_plans v2.1.2
*   pg_similarity
*   pg_smtp_client
*   pg_sparse
*   pg_squeeze
*   pg_stat_kcache v2.3.0
*   pg_stat_monitor
*   pg_store_plans