### PR TITLE
Update 11 more extensions for Postgres 17

### DIFF
--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -160,7 +160,7 @@ jobs:
         if: matrix.pg == 15
         shell: bash -e {0}
         run: |
-          for val in pg_cron timescaledb pg_search pg_analytics citus plrust pg_net pg_stat_kcache pg_squeeze pg_tle pgaudit; do
+          for val in pg_cron timescaledb pg_search pg_analytics citus plrust pg_net pg_stat_kcache pg_squeeze pg_tle pgaudit pglogical; do
             if [[ "${{ matrix.ext.path }}" == *"$val"* ]]; then
               echo handling shared_preload_libraries for $val
               echo "shared_preload_libraries = '$val'" >> /var/lib/postgresql/data2/postgresql.conf

--- a/contrib/pgbouncer_fdw/Dockerfile
+++ b/contrib/pgbouncer_fdw/Dockerfile
@@ -1,15 +1,9 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/CrunchyData/pgbouncer_fdw.git
-
-# Set project version
-ARG RELEASE=v1.1.0
-
-# Build extension
-RUN cd pgbouncer_fdw && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/CrunchyData/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pgbouncer_fdw/Trunk.toml
+++ b/contrib/pgbouncer_fdw/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pgbouncer_fdw"
-version = "1.1.0"
+version = "1.2.0"
 repository = "https://github.com/CrunchyData/pgbouncer_fdw"
 license = "PostgreSQL"
 description = "PostgreSQL Foreign Data Wrapper to Connect to pgbouncer."
@@ -9,12 +9,7 @@ documentation = "https://access.crunchydata.com/documentation/pgbouncer_fdw/late
 categories = ["connectors"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pgbouncer_fdw && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pgbouncer_fdw install"

--- a/contrib/pgcozy/Dockerfile
+++ b/contrib/pgcozy/Dockerfile
@@ -1,10 +1,12 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/vventirozos/pgcozy.git
-
-# Build extension
-RUN cd pgcozy && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+# ARG EXTENSION_VERSION
+ARG RELEASE=1f36036
+RUN git clone https://github.com/vventirozos/${EXTENSION_NAME}.git \
+    && cd ${EXTENSION_NAME} \
+    && git checkout ${RELEASE} \
+    && make

--- a/contrib/pgcozy/Trunk.toml
+++ b/contrib/pgcozy/Trunk.toml
@@ -8,12 +8,7 @@ documentation = "https://github.com/vventirozos/pgcozy"
 categories = ["index_table_optimizations"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pgcozy && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pgcozy install"

--- a/contrib/pgemailaddr/Dockerfile
+++ b/contrib/pgemailaddr/Dockerfile
@@ -5,8 +5,8 @@ FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 # Clone and build the extension.
 ARG EXTENSION_NAME
 # ARG EXTENSION_VERSION
-ARG RELEASE=f3d82fd
-RUN git clone https://github.com/michelp/${EXTENSION_NAME}.git \
+ARG RELEASE=77266f2
+RUN git clone https://github.com/petere/${EXTENSION_NAME}.git \
     && cd ${EXTENSION_NAME} \
     && git checkout ${RELEASE} \
     && make

--- a/contrib/pgemailaddr/Trunk.toml
+++ b/contrib/pgemailaddr/Trunk.toml
@@ -1,0 +1,14 @@
+[extension]
+name = "pgemailaddr"
+version = "1.0.0"
+repository = "https://github.com/petere/pgemailaddr"
+license = "PostgreSQL"
+description = "Email address type for PostgreSQL."
+documentation = "https://github.com/petere/pgemailaddr"
+categories = ["data_transformations"]
+
+[build]
+postgres_version = "17"
+platform = "linux/amd64"
+dockerfile = "Dockerfile"
+install_command = "make -C pgemailaddr install"

--- a/contrib/pgfaceting/Dockerfile
+++ b/contrib/pgfaceting/Dockerfile
@@ -1,20 +1,9 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
-# Extension build dependencies
-RUN apt-get update && apt-get install -y \
-    cmake
-
-# Clone repository
-RUN git clone https://github.com/cybertec-postgresql/pgfaceting.git
-
-# Set project version
-ARG RELEASE=v0.2.0
-
-# Build extension
-RUN cd pgfaceting && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/cybertec-postgresql/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pgfaceting/Trunk.toml
+++ b/contrib/pgfaceting/Trunk.toml
@@ -11,12 +11,7 @@ categories = ["search"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pgfaceting && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pgfaceting install"

--- a/contrib/pgfincore/Dockerfile
+++ b/contrib/pgfincore/Dockerfile
@@ -1,12 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/klando/pgfincore.git
-
-ARG RELEASE=1.2.4
-
-RUN cd pgfincore && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "${EXTENSION_VERSION}" https://github.com/klando/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pgfincore/Trunk.toml
+++ b/contrib/pgfincore/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pgfincore"
-version = "1.2.0"
+version = "1.3.1"
 repository = "https://github.com/klando/pgfincore"
 license = "Copyright"
 description = "Use mincore to explore linux (or BSD) cache memory."
@@ -11,12 +11,7 @@ categories = ["tooling_admin"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pgfincore && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pgfincore install"

--- a/contrib/pghydro/Dockerfile
+++ b/contrib/pghydro/Dockerfile
@@ -1,12 +1,9 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/pghydro/pghydro.git
-
-ARG RELEASE=v.6.6
-
-# Build extension
-RUN cd pghydro && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE}
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v.$(perl -E 'print shift =~ s/[.]0$//gr' "${EXTENSION_VERSION}")" https://github.com/${EXTENSION_NAME}/${EXTENSION_NAME}.git \
+    && printf "EXTENSION = pghydro\nDATA = \$(wildcard pghydro--*.sql)\nPGXS := \$(shell pg_config --pgxs)\ninclude \$(PGXS)\n" > ${EXTENSION_NAME}/Makefile \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pghydro/Trunk.toml
+++ b/contrib/pghydro/Trunk.toml
@@ -9,11 +9,7 @@ categories = ["data_transformations"]
 preload_libraries = ["pghydro, postgis"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pghydro
-    set -x
-    mv pghydro* /usr/share/postgresql/15/extension
-    """
+install_command = "make -C pghydro install"

--- a/contrib/pgjwt/Trunk.toml
+++ b/contrib/pgjwt/Trunk.toml
@@ -8,12 +8,7 @@ documentation = "https://github.com/michelp/pgjwt"
 categories = ["security"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pgjwt && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pgjwt install"

--- a/contrib/pgl_ddl_deploy/Dockerfile
+++ b/contrib/pgl_ddl_deploy/Dockerfile
@@ -1,15 +1,9 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/enova/pgl_ddl_deploy.git
-
-# Set project version
-ARG RELEASE=v2.1.0
-
-# Build extension
-RUN cd pgl_ddl_deploy && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/enova/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pgl_ddl_deploy/Trunk.toml
+++ b/contrib/pgl_ddl_deploy/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pgl_ddl_deploy"
-version = "2.1.0"
+version = "2.2.1"
 repository = "https://github.com/enova/pgl_ddl_deploy"
 license = "MIT"
 description = "Transparent Logical DDL Replication."
@@ -8,12 +8,7 @@ documentation = "https://github.com/enova/pgl_ddl_deploy"
 categories = ["orchestration"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pgl_ddl_deploy && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pgl_ddl_deploy install"

--- a/contrib/pglogical/Dockerfile
+++ b/contrib/pglogical/Dockerfile
@@ -1,9 +1,9 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
     libkrb5-dev \
     libselinux1-dev \
@@ -13,14 +13,8 @@ RUN apt-get update && apt-get install -y \
     libpam0g-dev \
     zlib1g-dev
 
-# Clone repository
-RUN git clone https://github.com/2ndQuadrant/pglogical.git
-
-# Set project version
-ARG RELEASE=REL2_4_3
-
-# Build extension
-RUN cd pglogical && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "REL$(perl -E 'print shift =~ s/\./_/gr' "${EXTENSION_VERSION}")" https://github.com/2ndQuadrant/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pglogical/Trunk.toml
+++ b/contrib/pglogical/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pglogical"
-version = "2.4.3"
+version = "2.4.5"
 repository = "https://github.com/2ndQuadrant/pglogical"
 license = "PostgreSQL"
 description = "PostgreSQL Logical Replication."
@@ -15,10 +15,4 @@ apt = ["libpq5", "libc6"]
 postgres_version = "15"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pglogical && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
-
+install_command = "make -C pglogical install"

--- a/contrib/pglogical_ticker/Dockerfile
+++ b/contrib/pglogical_ticker/Dockerfile
@@ -1,15 +1,9 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/enova/pglogical_ticker.git
-
-# Set project version
-ARG RELEASE=v1.4.1
-
-# Build extension
-RUN cd pglogical_ticker && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/enova/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pglogical_ticker/Trunk.toml
+++ b/contrib/pglogical_ticker/Trunk.toml
@@ -11,12 +11,7 @@ categories = ["change_data_capture"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pglogical_ticker && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C pglogical_ticker install"

--- a/contrib/pgmonitor/Dockerfile
+++ b/contrib/pgmonitor/Dockerfile
@@ -1,15 +1,9 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/CrunchyData/pgmonitor-extension.git
-
-# Set project version
+# Clone and build the extension.
+ARG EXTENSION_NAME
 ARG EXTENSION_VERSION
-
-# Build extension
-RUN cd pgmonitor-extension && \
-    git fetch origin v${EXTENSION_VERSION} && \
-    git checkout v${EXTENSION_VERSION} && \
-    make
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/CrunchyData/${EXTENSION_NAME}-extension.git \
+    && make -C ${EXTENSION_NAME}-extension

--- a/contrib/pgmonitor/Trunk.toml
+++ b/contrib/pgmonitor/Trunk.toml
@@ -8,9 +8,7 @@ documentation = "https://github.com/CrunchyData/pgmonitor-extension.git"
 categories = ["metrics"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pgmonitor-extension && make install
-    """
+install_command = "make -C pgmonitor-extension install"


### PR DESCRIPTION
Update the build scripting and, where denoted, upgrade the version for the following extensions:

*   pgbouncer_fdw v1.2.0
*   pgcozy
*   pgfaceting
*   pgfincore v1.3.1
*   pghydro
*   pgjwt
*   pgl_ddl_deploy v2.2.1
*   pglogical v2.4.5
*   pglogical_ticker
*   pgmonitor

Also add pgemailaddr, which was previously deployed to trunk manually.