### PR TITLE
 Update extensions T-Z for Postgres 17

### DIFF
--- a/contrib/tdigest/Dockerfile
+++ b/contrib/tdigest/Dockerfile
@@ -1,12 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/tvondra/tdigest.git
-
-ARG RELEASE=v1.4.0
-
-RUN cd tdigest && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/tvondra/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/tdigest/Trunk.toml
+++ b/contrib/tdigest/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "tdigest"
-version = "1.4.0"
+version = "1.4.2"
 repository = "https://github.com/tvondra/tdigest"
 license = "PostgreSQL"
 description = "PostgreSQL extension for estimating percentiles using t-digest."
@@ -11,12 +11,7 @@ categories = ["analytics"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd tdigest && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C tdigest install"

--- a/contrib/tds_fdw/Dockerfile
+++ b/contrib/tds_fdw/Dockerfile
@@ -1,8 +1,8 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libreadline-dev \
@@ -18,21 +18,8 @@ RUN apt-get update && apt-get install -y \
 	freetds-dev \
 	freetds-common
 
-# Clone repository
-RUN git clone https://github.com/postgres/postgres.git
-
-
-ARG PG_RELEASE=REL_15_3
-ARG RELEASE=v2.0.3
-
-# Build extension
-RUN cd postgres && \
-	git fetch origin ${PG_RELEASE} && \
-	git checkout ${PG_RELEASE} && \
-	./configure && \
-	cd contrib && \
-	git clone https://github.com/tds-fdw/tds_fdw.git && \
-	cd tds_fdw && \
-	git fetch origin ${RELEASE} && \
-	git checkout ${RELEASE} && \
-	make USE_PGXS=1
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/tds-fdw/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/tds_fdw/Trunk.toml
+++ b/contrib/tds_fdw/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "tds_fdw"
-version = "2.0.3"
+version = "2.0.4"
 repository = "https://github.com/tds-fdw/tds_fdw"
 license = "Copyright"
 description = "A PostgreSQL foreign data wrapper to connect to TDS databases (Sybase and Microsoft SQL Server)."
@@ -11,12 +11,7 @@ categories = ["connectors"]
 apt = ["libsybdb5", "libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd postgres/contrib/tds_fdw && make USE_PGXS=1 install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C tds_fdw USE_PGXS=1 install"

--- a/contrib/tembo_ivm/Dockerfile
+++ b/contrib/tembo_ivm/Dockerfile
@@ -1,12 +1,8 @@
-ARG PG_VERSION=17
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/tembo-io/pg_ivm.git
-
-ARG RELEASE=v1.9.1
-
-RUN cd pg_ivm && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/tembo-io/pg_ivm.git ${EXTENSION_NAME} \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/tembo_ivm/Trunk.toml
+++ b/contrib/tembo_ivm/Trunk.toml
@@ -15,9 +15,4 @@ apt = ["libc6"]
 postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd pg_ivm && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C tembo_ivm install"

--- a/contrib/temporal_tables/Dockerfile
+++ b/contrib/temporal_tables/Dockerfile
@@ -1,15 +1,9 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/arkhipov/temporal_tables.git
-
-# Set project version
-ARG RELEASE=v1.2.1
-
-# Build extension
-RUN cd temporal_tables && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/arkhipov/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/temporal_tables/Trunk.toml
+++ b/contrib/temporal_tables/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "temporal_tables"
-version = "1.2.1"
+version = "1.2.2"
 repository = "https://github.com/arkhipov/temporal_tables"
 license = "BSD-2-Clause"
 description = "Temporal Tables PostgreSQL Extension."
@@ -11,12 +11,7 @@ categories = ["auditing_logging"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd temporal_tables && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C temporal_tables install"

--- a/contrib/timescaledb/Dockerfile
+++ b/contrib/timescaledb/Dockerfile
@@ -1,23 +1,15 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
-RUN apt-get update && apt-get install -y \
-    cmake \
-    libkrb5-dev
+USER root
+RUN apt-get update && apt-get install -y cmake libkrb5-dev
 
-# Clone repository
-RUN git clone https://github.com/timescale/timescaledb.git
-
-# Set project version
-ARG RELEASE=2.13.1
-
-# Build extension
-RUN cd timescaledb && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    ./bootstrap -DAPACHE_ONLY=1 && \
-    cd build && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "${EXTENSION_VERSION}" https://github.com/timescale/${EXTENSION_NAME}.git \
+    && cd ${EXTENSION_NAME} \
+    && ./bootstrap -DAPACHE_ONLY=1 \
+    && make -C build

--- a/contrib/timescaledb/Trunk.toml
+++ b/contrib/timescaledb/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "timescaledb"
-version = "2.13.1"
+version = "2.17.2"
 repository = "https://github.com/timescale/timescaledb"
 license = "Apache-2.0"
 description = "An open-source time-series SQL database optimized for fast ingest and complex queries. Packaged as a PostgreSQL extension."
@@ -13,13 +13,7 @@ loadable_libraries = [{ library_name = "timescaledb", requires_restart = true }]
 apt = ["libssl3", "openssl", "libpq5", "libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd timescaledb/build && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
-
+install_command = "make -C timescaledb/build install"

--- a/contrib/vectorscale/Dockerfile
+++ b/contrib/vectorscale/Dockerfile
@@ -1,7 +1,8 @@
-ARG PG_VERSION=17
+ARG PG_VERSION
 FROM quay.io/coredb/pgrx-builder:pg${PG_VERSION}-pgrx0.12.5
-USER root
 
+# Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	libssl-dev \
@@ -11,24 +12,14 @@ RUN apt-get update && apt-get install -y \
     libopenblas-dev \
 	pkg-config
 
-# Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-RUN $HOME/.cargo/bin/cargo install cargo-pgrx --version=0.12.5 --locked
-ARG PG_VERSION=17
-RUN $HOME/.cargo/bin/cargo pgrx init --pg$PG_VERSION $(which pg_config)
+ARG PG_VERSION
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
 
-# # Set default Rust version
-RUN /root/.cargo/bin/rustup default stable
-
-# Clone repository
-RUN git clone https://github.com/timescale/pgvectorscale.git
-
-ARG EXTENSION_VERSION=0.5.1
-ARG PG_VERSION=17
-
-# Build extension
-RUN cd pgvectorscale/pgvectorscale && \
-	git fetch origin ${EXTENSION_VERSION} && \
-	git checkout ${EXTENSION_VERSION} && \
-    cargo pgrx init --pg${PG_VERSION} /usr/bin/pg_config && \
-    RUSTFLAGS="-C target-feature=+avx2,+fma" cargo pgrx package
+USER root
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    && /root/.cargo/bin/rustup default stable \
+    && git clone --depth 1 --branch ${EXTENSION_VERSION} https://github.com/timescale/pg${EXTENSION_NAME}.git \
+    && cd pg${EXTENSION_NAME}/pg${EXTENSION_NAME} \
+    && cargo pgrx init --pg${PG_VERSION} $(which pg_config) \
+    && RUSTFLAGS="-C target-feature=+avx2,+fma" cargo pgrx package

--- a/contrib/wal2json/Dockerfile
+++ b/contrib/wal2json/Dockerfile
@@ -1,11 +1,7 @@
-ARG PG_VERSION=15
+ARG PG_VERSION=
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-ARG RELEASE=wal2json_2_5
 
-# Clone repository
-RUN git clone https://github.com/eulerto/wal2json.git
-
-RUN cd wal2json && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "wal2json_$(perl -E 'print shift =~ s/[.]0$//r =~ s/[.]/_/gr' "${EXTENSION_VERSION}")" https://github.com/eulerto/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/contrib/wal2json/Trunk.toml
+++ b/contrib/wal2json/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "wal2json"
-version = "2.5.0"
+version = "2.6.0"
 repository = "https://github.com/eulerto/wal2json"
 license = "BSD-3-Clause"
 description = "wal2json is an output plugin for logical decoding."
@@ -10,7 +10,7 @@ categories = ["change_data_capture"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = "cd wal2json && make install"
+install_command = "make -C wal2json install"

--- a/contrib/zson/Dockerfile
+++ b/contrib/zson/Dockerfile
@@ -1,12 +1,11 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
-# Extension build dependencies
-RUN apt-get update && apt-get install -y \
-	build-essential
-
-# Clone repository
-RUN git clone https://github.com/postgrespro/zson
-
-RUN cd zson && make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+ARG RELEASE=e214c79
+RUN git clone https://github.com/postgrespro/${EXTENSION_NAME}.git \
+    && cd ${EXTENSION_NAME} \
+	&& git checkout ${RELEASE} \
+	&& make

--- a/contrib/zson/Trunk.toml
+++ b/contrib/zson/Trunk.toml
@@ -11,12 +11,7 @@ categories = ["data_transformations"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    cd zson && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C zson install"


### PR DESCRIPTION
Update the build scripting for the following extensions for PostgreSQL 17, and upgrade the version as marked.

*   tdigest 1.4.2
*   tds_fdw 2.0.4
*   tembo_ivm
*   temporal_tables 1.2.2
*   timescaledb 2.17.2
*   vectorscale
*   wal2json 2.6.0
*   zson