### PR TITLE
Update recent extension releases

### DIFF
--- a/contrib/lower_quantile/Dockerfile
+++ b/contrib/lower_quantile/Dockerfile
@@ -2,9 +2,8 @@ ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
 ARG EXTENSION_NAME
-# ARG EXTENSION_VERSION
-ARG RELEASE=12c48a7
-RUN git clone https://github.com/tvondra/${EXTENSION_NAME}.git \
-    && cd ${EXTENSION_NAME} \
-    && git checkout ${RELEASE} \
-    && make
+ARG EXTENSION_VERSION
+RUN curl -O https://api.pgxn.org/dist/${EXTENSION_NAME}/${EXTENSION_VERSION}/${EXTENSION_NAME}-${EXTENSION_VERSION}.zip \
+    && unzip ${EXTENSION_NAME}-${EXTENSION_VERSION}.zip \
+    && cd ${EXTENSION_NAME}-${EXTENSION_VERSION} && make
+WORKDIR /app/${EXTENSION_NAME}-${EXTENSION_VERSION}

--- a/contrib/lower_quantile/Trunk.toml
+++ b/contrib/lower_quantile/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "lower_quantile"
-version = "1.0.0"
+version = "1.0.3"
 repository = "https://github.com/tvondra/lower_quantile"
 license = "BSD-2-Clause"
 description = "Provides lower_quantile aggregate function."
@@ -11,7 +11,7 @@ categories = ["analytics"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = "make -C lower_quantile install"
+install_command = "make install"

--- a/contrib/pg_partman/Trunk.toml
+++ b/contrib/pg_partman/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_partman"
-version = "5.2.2"
+version = "5.2.3"
 repository = "https://github.com/pgpartman/pg_partman"
 license = "PostgreSQL"
 description = "Extension to manage partitioned tables by time or ID."

--- a/contrib/quantile/Trunk.toml
+++ b/contrib/quantile/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "quantile"
-version = "1.1.7"
+version = "1.1.8"
 repository = "https://github.com/tvondra/quantile"
 license = "BSD-2-Clause"
 description = "This extension provides three simple aggregate functions to compute quantiles."

--- a/contrib/sequential_uuids/Trunk.toml
+++ b/contrib/sequential_uuids/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "sequential_uuids"
-version = "1.0.2"
+version = "1.0.3"
 repository = "https://github.com/tvondra/sequential-uuids"
 license = "MIT"
 description = "Generator of sequential UUIDs."

--- a/contrib/smlar/Dockerfile
+++ b/contrib/smlar/Dockerfile
@@ -18,8 +18,9 @@ RUN apt-get update && apt-get install -y \
 
 ARG EXTENSION_NAME
 # ARG EXTENSION_VERSION
-ARG RELEASE=f2522d5
-RUN git clone https://github.com/jirutka/${EXTENSION_NAME}.git \
-    && cd ${EXTENSION_NAME} \
-    && git checkout ${RELEASE} \
+ARG RELEASE=6259352
+RUN curl -o "${EXTENSION_NAME}-${RELEASE}.tgz" "http://sigaev.ru/git/gitweb.cgi?p=${EXTENSION_NAME}.git;a=snapshot;h=${RELEASE};sf=tgz" \
+	&& tar zxf "${EXTENSION_NAME}-${RELEASE}.tgz" \
+    && cd "${EXTENSION_NAME}-${RELEASE}" \
     && make USE_PGXS=1
+WORKDIR /app/${EXTENSION_NAME}-${RELEASE}

--- a/contrib/smlar/Trunk.toml
+++ b/contrib/smlar/Trunk.toml
@@ -1,14 +1,14 @@
 [extension]
 name = "smlar"
 version = "1.0.0"
-repository = "https://github.com/jirutka/smlar/"
+repository = "http://sigaev.ru/git/gitweb.cgi?p=smlar.git;a=commit;h=6259352edd179544c6f0e7c81bb68dcb81317f8c"
 license = "PostgreSQL"
 description = "PostgreSQL extension for an effective similarity search"
-documentation = "https://github.com/jirutka/smlar/"
+documentation = "http://sigaev.ru/git/gitweb.cgi?p=smlar.git;a=blob;f=README;h=8fa81c51d749cc714e52257a15edf547f0b26edf;hb=HEAD"
 categories = ["search"]
 
 [build]
 postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = "make -C smlar USE_PGXS=1 install"
+install_command = "make USE_PGXS=1 install"


### PR DESCRIPTION
*   smlar was fixed for Postgres 16-17, but the GitHub mirror hasn't been updated. So fetch the sources from the project's own GitWeb interface.
*   lower_quantile was updated on PGXN, so switch to building releases from there.
*   Update pg_partman, quantile, and sequential_uuids to their latest releases.