### PR TITLE
Remove libgroonga0 package

### DIFF
--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -149,7 +149,6 @@ jobs:
           set -xe
           apt-get update
           apt-get install -y pkg-config libssl-dev gosu
-          apt-get remove -y libgroonga0
       - name: Build extension
         id: build
         run: cd ${{ matrix.ext.path }} && trunk build --pg-version ${{ matrix.pg }}

--- a/images/trunk-test-tembo/Dockerfile
+++ b/images/trunk-test-tembo/Dockerfile
@@ -38,7 +38,6 @@ RUN apt-get update && apt-get install -y \
     liblz4-1 \
     libpcre2-8-0 \
     libuuid1 \
-    libgroonga0 \
     libopenblas0-pthread \
     libcurl4 \
     libjson-c5 \
@@ -93,7 +92,7 @@ RUN wget https://packages.groonga.org/source/groonga/groonga-14.1.2.tar.gz \
     && ./configure \
     && make -j$(grep '^processor' /proc/cpuinfo | wc -l) \
     && make install \
-    && rm -rf groonga-14.1.2*
+    && cd .. && rm -rf groonga-14.1.2*
 
 RUN chown -R postgres:postgres $PGDATA && \
     chmod -R 0700 $PGDATA

--- a/registry/migrations/20250103230002_libgroonga0.sql
+++ b/registry/migrations/20250103230002_libgroonga0.sql
@@ -1,0 +1,5 @@
+-- Add migration script here
+UPDATE versions
+SET system_dependencies = '{"apt":["libc6"]}'::jsonb
+FROM extensions
+WHERE extensions.name = 'pgroonga' AND extensions.id = versions.extension_id;


### PR DESCRIPTION
It conflicts with the version installed from source. Add a migration to remove it from the registry, as well (it was added in `registry/migrations/20231006030851_fill-in-system-deps.sql`).