### PR TITLE
Refactor last bits of old-style build scripting

### DIFF
--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -36,7 +36,7 @@ jobs:
             changed_relative_to_ref="origin/${{ github.base_ref || 'not-a-branch' }}"
           fi
           echo "changed_relative_to_ref=${changed_relative_to_ref}" >> $GITHUB_OUTPUT
-      - name: Check out the coredb repo to reuse some actions
+      - name: Check out the repo to reuse some actions
         uses: actions/checkout@v4
         with:
           repository: tembo-io/tembo

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.15.7"
+version = "0.15.8"
 edition = "2021"
 authors = ["Ian Stanton", "Vinícius Miguel", "David E. Wheeler"]
 description = "A package manager for PostgreSQL extensions"

--- a/cli/README-DEV.md
+++ b/cli/README-DEV.md
@@ -20,9 +20,65 @@ The `--nocapture` option ensures all output prints to the terminal. The
 `--test-threads=4` limits the number of threads so as not to overwhelm Docker
 (seems especially prone with macOS Docker's VM).
 
+## Docker Desktop
+
+Start a pgxn-tools privileged container with the repository directory mounted:
+
+```sh
+cd trunk
+docker run -it --rm -v "$PWD:/repo" --privileged --platform linux/amd64 -w /repo pgxn/pgxn-tools bash
+```
+
+Inside the container, follow the [installation instructions] to set up the Apt repo:
+
+``` sh
+# Add Docker's official GPG key:
+sudo apt-get update
+sudo apt-get install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+```
+
+Install Docker:
+
+``` sh
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+```
+
+Fix [bug] and start Docker:
+
+``` sh
+perl -i -pe 's/ulimit -Hn/ulimit -n/' /etc/init.d/docker
+systemctl start docker
+```
+
+Install and start Postgres and upgrade Rust:
+
+``` sh
+pg-start 15
+rustup update
+```
+
+Run the tests:
+
+``` sh
+cd cli
+cargo test -- --nocapture --test-threads=4
+```
+
   [Postgres]: https://www.postgresql.org
     "PostgreSQL: The World's Most Advanced Open Source Relational Database"
   [`pg_config`]: https://www.postgresql.org/docs/current/app-pgconfig.html
     "PostgreSQL Docs: pg_config"
   [Docker]: https://www.docker.com
     "Docker: Accelerated Container Application Development"
+  [installation instructions]: https://docs.docker.com/engine/install/debian/#install-using-the-repository
+  [bug]: https://forums.docker.com/t/etc-init-d-docker-62-ulimit-error-setting-limit-invalid-argument-problem/139424/2

--- a/cli/src/commands/containers.rs
+++ b/cli/src/commands/containers.rs
@@ -676,14 +676,22 @@ fn prepare_sharedir_file<'p>(
     let file_to_package = file_to_package.strip_prefix(sharedir)?;
 
     match maybe_directory {
-        Some(diretory) => {
+        Some(directory) => {
+            // Return the file already starts with the directory.
+            if let Some(prefix) = file_to_package.components().next() {
+                if prefix.as_os_str().as_encoded_bytes() == directory.as_bytes() {
+                    // The file already starts with the directory name.
+                    return Ok(file_to_package.into());
+                }
+            }
+
             // If the file starts with `extension/`, remove it so that we can add the correct directory path supplied
             // in the `directory` field.
             let file_to_package = file_to_package
                 .strip_prefix("extension")
                 .unwrap_or(file_to_package);
 
-            Ok(Path::new(diretory).join(file_to_package).into())
+            Ok(Path::new(directory).join(file_to_package).into())
         }
         None => Ok(file_to_package.into()),
     }

--- a/cli/tests/test_builders/Dockerfile.auto_explain
+++ b/cli/tests/test_builders/Dockerfile.auto_explain
@@ -1,15 +1,13 @@
-ARG PG_VERSION=15
-
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-
-ARG PG_VERSION=15
-
-USER root
 
 # Postgres build dependencies
 # https://wiki.postgresql.org/wiki/Compile_and_Install_from_source_code
+USER root
 RUN apt-get update && apt-get install -y  build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev libssl-dev libxml2-utils xsltproc ccache
 
-COPY --chown=postgres:postgres . .
-RUN ./configure
-RUN cd contrib/auto_explain && make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/cli/tests/test_builders/Dockerfile.http
+++ b/cli/tests/test_builders/Dockerfile.http
@@ -1,10 +1,12 @@
-FROM quay.io/coredb/c-builder:pg15
-
-COPY --chown=postgres:postgres . .
-
-USER root
+ARG PG_VERSION
+FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
 # this is the extra library we need to build pgsql-http
+USER root
 RUN apt-get update && apt-get install -y libcurl4-openssl-dev
 
-RUN make
+# Clone and build the extension.
+# ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/pramsey/pgsql-http.git \
+    && make -C pgsql-http

--- a/cli/tests/test_builders/Dockerfile.pg_stat_statements
+++ b/cli/tests/test_builders/Dockerfile.pg_stat_statements
@@ -1,15 +1,13 @@
-ARG PG_VERSION=15
-
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-
-ARG PG_VERSION=15
-
-USER root
 
 # Postgres build dependencies
 # https://wiki.postgresql.org/wiki/Compile_and_Install_from_source_code
+USER root
 RUN apt-get update && apt-get install -y  build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev libssl-dev libxml2-utils xsltproc ccache
 
-COPY --chown=postgres:postgres . .
-RUN ./configure
-RUN cd contrib/pg_stat_statements && make
+# Clone repository and build extension.
+ARG EXTENSION_NAME
+ARG PG_RELEASE
+RUN git clone --depth 1 --branch "${PG_RELEASE}" https://github.com/postgres/postgres.git \
+	&& make -C postgres/contrib/${EXTENSION_NAME} USE_PGXS=1

--- a/cli/tests/test_pljava/Dockerfile
+++ b/cli/tests/test_pljava/Dockerfile
@@ -1,5 +1,5 @@
 # Set PostgreSQL version
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 USER root
 
@@ -10,14 +10,9 @@ RUN apt-get update && apt-get install -y \
     libkrb5-dev \
     libecpg-dev
 
-# Clone repository
-RUN git clone https://github.com/tada/pljava.git
-
-# Set project version
-ARG RELEASE=V1_6_5
-
-# Build extension
-RUN cd pljava && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    mvn clean install
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "V$(perl -E 'print shift =~ s/\./_/gr' "${EXTENSION_VERSION}")" https://github.com/tada/${EXTENSION_NAME}.git \
+	&& cd ${EXTENSION_NAME} \
+    && mvn clean install

--- a/cli/tests/test_pljava/Trunk.toml
+++ b/cli/tests/test_pljava/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pljava"
-version = "1.6.5"
+version = "1.6.8"
 repository = "https://github.com/tada/pljava"
 license = "BSD-3-Clause"
 description = "Java Procedural Language for PostgreSQL"
@@ -11,19 +11,8 @@ categories = ["procedural_languages"]
 apt = ["libc6", "openjdk-11-jdk"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 include = ["*.jar"]
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    mkdir /app/pljava/pljava-packaging/target/unpacked
-    cd /app/pljava/pljava-packaging/target/unpacked
-    jar -xf /app/pljava/pljava-packaging/target/pljava-pg15.jar
-    set -x
-    mv /app/pljava/pljava-packaging/target/unpacked/pljava/sharedir/pljava/* /usr/share/postgresql/15/extension
-    mv /app/pljava/pljava-packaging/target/unpacked/pljava/sharedir/extension/* /usr/share/postgresql/15/extension
-    mv /app/pljava/pljava-so/target/pljava-pgxs/* /usr/lib/postgresql/15/lib
-    """
-
-
-
+install_command = "java -jar pljava/pljava-packaging/target/pljava-pg17.jar"

--- a/cli/tests/test_postgresql_unit/Dockerfile
+++ b/cli/tests/test_postgresql_unit/Dockerfile
@@ -1,12 +1,13 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Clone repository
-RUN git clone https://github.com/df7cb/postgresql-unit.git
-
-ARG RELEASE=7.7
-
-RUN cd postgresql-unit && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    make
+# Clone and build the extension.
+# ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "$(perl -E 'print shift =~ s/[.]0$//gr' "${EXTENSION_VERSION}")" https://github.com/df7cb/postgresql-unit.git \
+    # Build .sql files to point to the Tembo image share directory before
+    # building everything else. Forces these lines to have the values we need:
+    # https://github.com/df7cb/postgresql-unit/blob/7.10/Makefile#L44-L45
+    && make -C postgresql-unit datadir=/var/lib/postgresql/data/tembo *.sql \
+    # Build everything else as usual.
+    && make -C postgresql-unit

--- a/cli/tests/test_postgresql_unit/Trunk.toml
+++ b/cli/tests/test_postgresql_unit/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "postgresql_unit"
-version = "7.0.0"
+version = "7.10.0"
 repository = "https://github.com/df7cb/postgresql-unit"
 license = "Copyright"
 description = "SI Units for PostgreSQL."
@@ -11,13 +11,9 @@ categories = ["analytics"]
 apt = ["libc6"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
+install_command = "make -C postgresql-unit install"
+# Tell trunk to include unit_prefixes.data and unit_units.data.
 include = ["*.data"]
-install_command = """
-    cd postgresql-unit && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """

--- a/cli/tests/test_trunk_toml_dirs/pg_cron/Dockerfile
+++ b/cli/tests/test_trunk_toml_dirs/pg_cron/Dockerfile
@@ -1,9 +1,8 @@
-FROM quay.io/coredb/c-builder:pg15
+ARG PG_VERSION
+FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-ARG VERSION=1.5.2
-
-RUN git clone https://github.com/citusdata/pg_cron.git
-RUN cd pg_cron && \
-  git fetch origin v${VERSION} && \
-  git checkout v${VERSION} && \
-  make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/citusdata/${EXTENSION_NAME}.git \
+    && make -C ${EXTENSION_NAME}

--- a/cli/tests/test_trunk_toml_dirs/pg_cron/Trunk.toml
+++ b/cli/tests/test_trunk_toml_dirs/pg_cron/Trunk.toml
@@ -2,7 +2,7 @@
 name = "pg_cron"
 extension_name = "extension_name_from_toml"
 extension_dependencies = ["btree_gin"]
-version = "1.5.2"
+version = "1.6.4"
 repository = "https://github.com/tembo-io/trunk"
 license = "PostgreSQL"
 categories = []
@@ -18,7 +18,7 @@ configurations = [
 
 [build]
 dockerfile = "Dockerfile"
-install_command = "cd pg_cron && make install"
+install_command = "make -C pg_cron install"
 platform = "linux/amd64"
 
 [dependencies]

--- a/cli/tests/test_trunk_toml_dirs/postgis/Trunk.toml
+++ b/cli/tests/test_trunk_toml_dirs/postgis/Trunk.toml
@@ -16,9 +16,4 @@ postgres_version = "15"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
 #include = ["/app/postgis-3.so"]
-install_command = """
-    cd postgis-3.4.0/ && make install
-    set -x
-    mv /usr/local/pgsql/share/extension/* /usr/share/postgresql/15/extension
-    mv /usr/local/pgsql/lib/* /usr/lib/postgresql/15/lib
-    """
+install_command = "make -C postgis-3.4.0 install"

--- a/contrib/clickhouse_fdw/Dockerfile
+++ b/contrib/clickhouse_fdw/Dockerfile
@@ -1,25 +1,17 @@
 # Set PostgreSQL version
-ARG PG_VERSION=17
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
-USER root
 
 # Extension build dependencies
+USER root
 RUN apt-get update && apt-get install -y \
     cmake \
     libcurl4-openssl-dev \
     uuid-dev
 
-# Clone repository
-RUN git clone https://github.com/ildus/clickhouse_fdw.git
-
-# Set project version
-ARG RELEASE=1.4.0
-
-# Build extension
-RUN cd clickhouse_fdw && \
-    git fetch origin ${RELEASE} && \
-    git checkout ${RELEASE} && \
-    mkdir build && \
-    cd build && \
-    cmake .. && \
-    make
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "${EXTENSION_VERSION}" https://github.com/ildus/${EXTENSION_NAME}.git \
+    && cmake -S ${EXTENSION_NAME} -B ${EXTENSION_NAME}/build \
+    && make -C ${EXTENSION_NAME}/build -j8

--- a/contrib/clickhouse_fdw/Trunk.toml
+++ b/contrib/clickhouse_fdw/Trunk.toml
@@ -14,4 +14,4 @@ apt = ["libstdc++6", "libc6", "libgcc-s1"," libuuid1", "libcurl4"]
 postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = "cd clickhouse_fdw/build && make install"
+install_command = "make -C clickhouse_fdw/build install"

--- a/contrib/mobilitydb/Dockerfile
+++ b/contrib/mobilitydb/Dockerfile
@@ -22,7 +22,5 @@ ARG EXTENSION_NAME
 ARG EXTENSION_VERSION
 RUN trunk install postgis \
     && git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/${EXTENSION_NAME}/${EXTENSION_NAME}.git \
-    && mkdir -p ${EXTENSION_NAME}/build \
-    && cd ${EXTENSION_NAME}/build \
-    && cmake .. \
-    && make
+    && cmake -S ${EXTENSION_NAME} -B ${EXTENSION_NAME}/build \
+    && make -C ${EXTENSION_NAME}/build -j8

--- a/contrib/pgrouting/Dockerfile
+++ b/contrib/pgrouting/Dockerfile
@@ -13,7 +13,5 @@ RUN apt-get update && apt-get install -y \
 ARG EXTENSION_NAME
 ARG EXTENSION_VERSION
 RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/${EXTENSION_NAME}/${EXTENSION_NAME}.git \
-    && mkdir -p ${EXTENSION_NAME}/build  \
-    && cd ${EXTENSION_NAME}/build  \
-    && cmake .. \
-    && make
+    && cmake -S ${EXTENSION_NAME} -B ${EXTENSION_NAME}/build \
+    && make -C ${EXTENSION_NAME}/build -j8

--- a/contrib/pgrouting/Trunk.toml
+++ b/contrib/pgrouting/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pgrouting"
-version = "3.7.0"
+version = "3.7.1"
 repository = "https://github.com/pgRouting/pgrouting"
 license = "GPL-2.0"
 description = "pgRouting extends the PostGIS / PostgreSQL geospatial database to provide geospatial routing functionality."

--- a/contrib/pljava/Trunk.toml
+++ b/contrib/pljava/Trunk.toml
@@ -8,10 +8,11 @@ documentation = "https://tada.github.io/pljava/"
 categories = ["procedural_languages"]
 
 [dependencies]
-apt = ["libc6"]
+apt = ["libc6", "openjdk-11-jdk"]
 
 [build]
 postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
 install_command = "java -jar pljava/pljava-packaging/target/pljava-pg17.jar"
+include = ["*.jar"]

--- a/contrib/rdkit/Dockerfile
+++ b/contrib/rdkit/Dockerfile
@@ -1,36 +1,36 @@
-ARG PG_VERSION=15
+ARG PG_VERSION
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
+
 USER root
-
 RUN apt-get update && apt-get install -y \
- build-essential \
- libreadline-dev \
- zlib1g-dev \
- flex \
- bison \
- libxml2-dev \
- libxslt-dev \
- libssl-dev \
- libxml2-utils \
- xsltproc \
- ccache \
- cmake \
- gcc \
- libboost-all-dev \
- libfreetype6-dev \
- postgresql-server-dev-all
-
-ARG RELEASE=Release_2023_03_2
-ARG RDBASE=rdkit-${RELEASE}
+    build-essential \
+    libreadline-dev \
+    zlib1g-dev \
+    flex \
+    bison \
+    libxml2-dev \
+    libxslt-dev \
+    libssl-dev \
+    libxml2-utils \
+    xsltproc \
+    ccache \
+    cmake \
+    gcc \
+    libboost-all-dev \
+    libfreetype6-dev
 
 # Build and Install RDKit
-RUN wget https://github.com/rdkit/rdkit/archive/${RELEASE}.tar.gz && \
-    tar xvf ${RELEASE}.tar.gz && \
-    cd ${RDBASE} && \
-    mkdir build && \
-    cd build && \
-    cmake -DRDK_BUILD_PGSQL=ON \
-    -DRDK_BUILD_PYTHON_WRAPPERS=OFF \
-    -DRDK_BUILD_CPP_TESTS=OFF \
-    -DPostgreSQL_CONFIG_DIR=/usr/bin .. && \
-    make -j8
+ARG EXTENSION_NAME
+# ARG EXTENSION_VERSION
+ARG RELEASE=Release_2024_09_4
+RUN curl -LO https://github.com/${EXTENSION_NAME}/${EXTENSION_NAME}/archive/${RELEASE}.tar.gz \
+    && tar xvf ${RELEASE}.tar.gz \
+    && cd ${EXTENSION_NAME}-${RELEASE} \
+    && cmake -B build \
+        -D RDK_BUILD_PGSQL=ON \
+        -D RDK_BUILD_PYTHON_WRAPPERS=OFF \
+        -D PostgreSQL_CONFIG_DIR=/usr/bin \
+        -D "PostgreSQL_INCLUDE_DIR=$(pg_config --includedir)" \
+        -D "PostgreSQL_TYPE_INCLUDE_DIR=$(pg_config --includedir-server)" \
+    && make -j8 -C build
+WORKDIR /app/${EXTENSION_NAME}-${RELEASE}

--- a/contrib/rdkit/Trunk.toml
+++ b/contrib/rdkit/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "rdkit"
-version = "4.3.0"
+version = "4.6.1"
 repository = "https://github.com/rdkit/rdkit/tree/master/Code/PgSQL/rdkit"
 license = "BSD-3-Clause"
 description = "Cheminformatics functionality for PostgreSQL."
@@ -12,10 +12,7 @@ categories = ["data_transformations"]
 apt = ["libfreetype6", "libboost-serialization1.74.0", "libc6", "libstdc++6", "libgcc-s1"]
 
 [build]
-postgres_version = "15"
+postgres_version = "17"
 platform = "linux/amd64"
 dockerfile = "Dockerfile"
-install_command = """
-    sh rdkit-Release_2023_03_2/build/Code/PgSQL/rdkit/pgsql_install.sh
-    """
-
+install_command = "make -C build install"


### PR DESCRIPTION
The exceptions are `parquet_s3_fdw` and `postgresml`, which I cannot get to build. The updated extensions are:

*   clickhouse_fdw
*   rdkit (which never built before?)

Also simplified the use of `cmake` in these extensions:

*   mobilitydb
*   pgrouting

And upgraded these extensions to:

*   rdkit 4.6.1
*   pgrouting 3.7.1

Next, make sure that pljava properly depends on `openjdk-11-jdk`.

Upgrade the build scripting in tests:

*   cli/tests/test_builders/Dockerfile.auto_explain
*   cli/tests/test_builders/Dockerfile.http
*   cli/tests/test_builders/Dockerfile.pg_stat_statements
*   cli/tests/test_pljava
*   cli/tests/test_postgresql_unit
*   cli/tests/test_postgresql_unit
*   cli/tests/test_trunk_toml_dirs/pg_cron
*   cli/tests/test_trunk_toml_dirs/postgis

The `pljava` test revealed that the pattern adopted in  the last month to use `make install` rather than to `mv` files broke extensions configured with a `directory` in their control files, doubling the directory prefix. Update `prepare_sharedir_file` to notice when files already start with the `directory` prefix, but keep the old behavior of stripping out `extensions` for any lingering `mv` use cases.

Finally, update the README with the cleaner output and add some notes for running tests in Docker Desktop.