### PR TITLE
Fix control file location with directory config (#888)

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.15.8"
+version = "0.15.9"
 edition = "2021"
 authors = ["Ian Stanton", "Vinícius Miguel", "David E. Wheeler"]
 description = "A package manager for PostgreSQL extensions"

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -89,7 +89,7 @@ fn build_and_install_extension_with_directory_field() -> Result<(), Box<dyn std:
     let pkglibdir = pg_config_path("pkglibdir")?;
 
     // Make sure files were installed.
-    assert!(sharedir.join("pljava/pljava.control").exists());
+    assert!(sharedir.join("extension/pljava.control").exists());
     assert!(sharedir.join("pljava/pljava-1.6.8.jar").exists());
     assert!(sharedir.join("pljava/pljava-api-1.6.8.jar").exists());
     assert!(sharedir.join("pljava/pljava--1.6.8.sql").exists());


### PR DESCRIPTION
The control file must *always* go in the `extension` directory, never the directory specified in the control file. Otherwise Postgres can't find it!