### PR TITLE
Manually specify extensions to build (#890)

### DIFF
--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -57,14 +57,22 @@ jobs:
       - dind
       - xlarge-16x16
     container:
-      image: quay.io/tembo/trunk-test-tembo:1d073a4-pg15
+      image: quay.io/tembo/trunk-test-tembo:8a3bd64-pg15
       options: --user root
     needs:
       - find_directories
     strategy:
       fail-fast: false
       matrix:
-        ext: ${{ fromJson(needs.find_directories.outputs.directories).include }}
+        # ext: ${{ fromJson(needs.find_directories.outputs.directories).include }}
+        ext:
+          - { name: pgfincore,             path: "./contrib/pgfincore" }
+          - { name: pgtelemetry,           path: "./contrib/pgtelemetry" }
+          - { name: pljava,                path: "./contrib/pljava" }
+          - { name: postgresql_anonymizer, path: "./contrib/postgresql_anonymizer" }
+          - { name: emaj,                  path: "./contrib/emaj" }
+          - { name: pg_semver,             path: "./contrib/pg_semver" }
+          - { name: rdkit,                 path: "./contrib/rdkit" }
         pg: [15]
         exclude:
           # pg_hint_plan has separate extensions for each major version
@@ -92,14 +100,22 @@ jobs:
       - dind
       - xlarge-16x16
     container:
-      image: quay.io/tembo/trunk-test-tembo:1d073a4-pg15
+      image: quay.io/tembo/trunk-test-tembo:8a3bd64-pg15
       options: --user root
     needs:
       - find_directories
     strategy:
       fail-fast: false
       matrix:
-        ext: ${{ fromJson(needs.find_directories.outputs.directories).include }}
+        # ext: ${{ fromJson(needs.find_directories.outputs.directories).include }}
+        ext:
+          - { name: pgfincore,             path: "./contrib/pgfincore" }
+          - { name: pgtelemetry,           path: "./contrib/pgtelemetry" }
+          - { name: pljava,                path: "./contrib/pljava" }
+          - { name: postgresql_anonymizer, path: "./contrib/postgresql_anonymizer" }
+          - { name: emaj,                  path: "./contrib/emaj" }
+          - { name: pg_semver,             path: "./contrib/pg_semver" }
+          - { name: rdkit,                 path: "./contrib/rdkit" }
         pg: [17, 16, 15, 14]
         exclude:
           - { pg: 14, ext: { name: pg_walinspect  } } # Added in Postgres 17
@@ -148,7 +164,7 @@ jobs:
         run: |
           set -xe
           apt-get update
-          apt-get install -y pkg-config libssl-dev gosu
+          apt-get install -y pkg-config libssl-dev gosu openjdk-11-jdk
       - name: Build extension
         id: build
         run: cd ${{ matrix.ext.path }} && trunk build --pg-version ${{ matrix.pg }}
@@ -160,10 +176,10 @@ jobs:
         if: matrix.pg == 15
         shell: bash -e {0}
         run: |
-          for val in pg_cron timescaledb pg_search pg_analytics citus plrust pg_net pg_stat_kcache pg_squeeze pg_tle pgaudit pglogical; do
-            if [[ "${{ matrix.ext.path }}" == *"$val"* ]]; then
-              echo handling shared_preload_libraries for $val
-              echo "shared_preload_libraries = '$val'" >> /var/lib/postgresql/data2/postgresql.conf
+          for val in pg_cron timescaledb pg_search pg_analytics citus plrust pg_net pg_stat_kcache pg_squeeze pg_tle pgaudit pglogical anon:postgresql_anonymizer; do
+            if [[ "${{ matrix.ext.path }}" == *"${val#*:}"* ]]; then
+              echo handling shared_preload_libraries for ${val#*:}
+              echo "shared_preload_libraries = '${val%:*}'" >> /var/lib/postgresql/data2/postgresql.conf
             fi
           done
       - name: Enable the extension

--- a/contrib/mobilitydb/Dockerfile
+++ b/contrib/mobilitydb/Dockerfile
@@ -1,6 +1,6 @@
 ARG PG_VERSION
-# Set up iamge to copy trunk from.
-FROM quay.io/tembo/trunk-test-tembo:1d073a4-pg15 AS trunk
+# Set up image to copy trunk from.
+FROM quay.io/tembo/trunk-test-tembo:8a3bd64-pg15 AS trunk
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
 USER root

--- a/contrib/pljava/Dockerfile
+++ b/contrib/pljava/Dockerfile
@@ -15,4 +15,4 @@ ARG EXTENSION_NAME
 ARG EXTENSION_VERSION
 RUN git clone --depth 1 --branch "V$(perl -E 'print shift =~ s/\./_/gr' "${EXTENSION_VERSION}")" https://github.com/tada/${EXTENSION_NAME}.git \
 	&& cd ${EXTENSION_NAME} \
-    && mvn clean install
+    && mvn clean install -Dpljava.libjvmdefault=/usr/lib/x86_64-linux-gnu/libjvm.so


### PR DESCRIPTION
Force the extensions workflow to build the extensions known to have `directory` fields in their control files, so as to fix them. Upgrade to `trunk-test-tembo:b699861-pg15` to get that fix, made in c3154c (#888) and released in b699861 (#889).

As a result of failures revealed by fixing these issues, also teach PL/Java where to find `libjvm.so` and the workflow to preload the `anon` module when testing postgresql_anonymizer.