### PR TITLE
Fix subdirectories, tabs in control file (#891)

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.15.9"
+version = "0.15.10"
 edition = "2021"
 authors = ["Ian Stanton", "Vinícius Miguel", "David E. Wheeler"]
 description = "A package manager for PostgreSQL extensions"

--- a/cli/src/commands/containers.rs
+++ b/cli/src/commands/containers.rs
@@ -678,17 +678,19 @@ fn prepare_sharedir_file<'p>(
     }
 
     // If the control file was not supplied, or it was and didn't have the `directory` field filled in,
-    // assume the file should go to `$(sharedir)/extension`.
+    // assume the file should go to `$(sharedir)/extension)`.
     let maybe_directory = control_file.and_then(|file| file.directory.as_ref());
 
     match maybe_directory {
         Some(directory) => {
-            // Return the file already starts with the directory.
-            if let Some(prefix) = file_to_package.components().next() {
-                if prefix.as_os_str().as_encoded_bytes() == directory.as_bytes() {
-                    // The file already starts with the directory name.
-                    return Ok(file_to_package.into());
-                }
+            // Remove trailing directory separator.
+            let directory = directory.trim_end_matches(['/', '\\']);
+
+            // Return file if already starts with the directory (which may
+            // include subdirectories).
+            if file_to_package.starts_with(format!("{directory}{}", std::path::MAIN_SEPARATOR)) {
+                // The file already starts with the directory name.
+                return Ok(file_to_package.into());
             }
 
             // If the file starts with `extension/`, remove it so that we can add the correct directory path supplied

--- a/cli/src/control_file.rs
+++ b/cli/src/control_file.rs
@@ -56,10 +56,11 @@ impl ControlFile {
 }
 
 pub fn strip_value(input: &str) -> &str {
-    let stripped = input.trim_start_matches([' ', '=']);
-
-    let trimmed = stripped.trim_start();
-    trimmed.trim_matches('\'')
+    input
+        .trim_start()
+        .trim_start_matches('=')
+        .trim_start()
+        .trim_matches('\'')
 }
 
 #[cfg(test)]
@@ -79,6 +80,22 @@ mod tests {
         let control_file = ControlFile::parse(contents);
 
         assert_eq!(control_file.directory.unwrap(), "pljava");
+    }
+
+    #[test]
+    fn parses_variously_spaced_fields() {
+        // Note the \t on the `directory` line.
+        let contents = r#"
+        default_version='4.5.0'
+        requires= 'help'
+        module_pathname='$libdir/emaj'
+        directory 	    = 'emaj'
+        "#;
+
+        let control_file = ControlFile::parse(contents);
+        assert_eq!(control_file.directory.unwrap(), "emaj");
+        assert_eq!(control_file.module_pathname.unwrap(), "$libdir/emaj");
+        assert_eq!(control_file.requires.unwrap(), vec!["help"]);
     }
 
     #[test]


### PR DESCRIPTION
Fix a few issues working with the `directory` field from control files:

*   `emaj` failed to work because it has a tab on the `directory` line of its control file. Fix `strip_value` to account for any and all blank space on either side of the `=` in a field config.
*   `postgresql_anonymizer` failed to build because it specifies `extension/anon` for the `directory` field. Update the examination of file prefixes in `prepare_sharedir_file` to allow subdirectories.