### PR TITLE
Restore duckdb_fdw and add pg_duckdb

### DIFF
--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -57,7 +57,7 @@ jobs:
       - dind
       - xlarge-16x16
     container:
-      image: quay.io/tembo/trunk-test-tembo:5deab41-pg15
+      image: quay.io/tembo/trunk-test-tembo:73092d1-pg15
       options: --user root
     needs:
       - find_directories
@@ -92,7 +92,7 @@ jobs:
       - dind
       - xlarge-16x16
     container:
-      image: quay.io/tembo/trunk-test-tembo:5deab41-pg15
+      image: quay.io/tembo/trunk-test-tembo:73092d1-pg15
       options: --user root
     needs:
       - find_directories
@@ -160,7 +160,7 @@ jobs:
         if: matrix.pg == 15
         shell: bash -e {0}
         run: |
-          for val in pg_cron timescaledb pg_search pg_analytics citus plrust pg_net pg_stat_kcache pg_squeeze pg_tle pgaudit pglogical anon:postgresql_anonymizer pgml:postgresml; do
+          for val in pg_cron timescaledb pg_search pg_analytics citus plrust pg_net pg_stat_kcache pg_squeeze pg_tle pgaudit pglogical pg_duckdb anon:postgresql_anonymizer pgml:postgresml; do
             if [[ "${{ matrix.ext.path }}" == *"${val#*:}"* ]]; then
               echo handling shared_preload_libraries for ${val#*:}
               echo "shared_preload_libraries = '${val%:*}'" >> /var/lib/postgresql/data2/postgresql.conf

--- a/contrib/duckdb_fdw/Dockerfile
+++ b/contrib/duckdb_fdw/Dockerfile
@@ -1,0 +1,19 @@
+ARG PG_VERSION=17
+FROM quay.io/coredb/c-builder:pg${PG_VERSION}
+
+# Download and install the DuckDB DSO.
+ARG EXTENSION_VERSION
+ENV DUCKDB_VERSION=${EXTENSION_VERSION}
+USER root
+# Funky naming expectations: https://github.com/alitrack/duckdb_fdw/issues/64
+RUN curl -LO https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/libduckdb-linux-amd64.zip \
+    && unzip -d . libduckdb-linux-amd64.zip \
+    && install -m 755 libduckdb.so "/usr/local/lib/libduckdb.${DUCKDB_VERSION}.so" \
+    && (cd /usr/local/lib && ln -s "libduckdb.${DUCKDB_VERSION}.so" "libduckdb.so")
+
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/alitrack/${EXTENSION_NAME}.git \
+    && perl -i -pe 's/^install:/#/' "${EXTENSION_NAME}/Makefile" \
+    && make -C ${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/duckdb_fdw/Trunk.toml
+++ b/contrib/duckdb_fdw/Trunk.toml
@@ -1,0 +1,15 @@
+[extension]
+name = "duckdb_fdw"
+version = "1.1.3"
+repository = "https://github.com/alitrack/duckdb_fdw"
+license = "MIT"
+description = "This PostgreSQL extension implements a Foreign Data Wrapper (FDW) for DuckDB."
+homepage = "https://alitrack.com/"
+documentation = "https://github.com/alitrack/duckdb_fdw"
+categories = ['connectors']
+
+[build]
+postgres_version = "17"
+platform = "linux/amd64"
+dockerfile = "Dockerfile"
+install_command = "make -C duckdb_fdw install USE_PGXS=1"

--- a/contrib/mobilitydb/Dockerfile
+++ b/contrib/mobilitydb/Dockerfile
@@ -1,6 +1,6 @@
 ARG PG_VERSION
 # Set up image to copy trunk from.
-FROM quay.io/tembo/trunk-test-tembo:5deab41-pg15 AS trunk
+FROM quay.io/tembo/trunk-test-tembo:73092d1-pg15 AS trunk
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
 USER root

--- a/contrib/pg_duckdb/Dockerfile
+++ b/contrib/pg_duckdb/Dockerfile
@@ -1,0 +1,29 @@
+ARG PG_VERSION=17
+FROM quay.io/coredb/c-builder:pg${PG_VERSION}
+
+# Install dependencies.
+USER root
+RUN apt-get update && \
+    apt-get install -y \
+    libreadline-dev \
+    zlib1g-dev \
+    flex bison \
+    libxml2-dev \
+    libxslt-dev \
+    libxml2-utils \
+    xsltproc \
+    libc++-dev \
+    libc++abi-dev \
+    libglib2.0-dev \
+    libtinfo6\
+    libstdc++-12-dev \
+    liblz4-dev \
+    ninja-build
+
+# Clone and build the extension.
+ARG EXTENSION_NAME
+ARG EXTENSION_VERSION
+RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/duckdb/${EXTENSION_NAME}.git \
+    && cd ${EXTENSION_NAME} \
+    && git submodule update --depth 1 --init --recursive \
+    && make

--- a/contrib/pg_duckdb/Trunk.toml
+++ b/contrib/pg_duckdb/Trunk.toml
@@ -1,0 +1,15 @@
+[extension]
+name = "pg_duckdb"
+version = "0.2.0"
+repository = "https://github.com/duckdb/pg_duckdb"
+license = "MIT"
+description = "DuckDB-powered Postgres for high performance apps & analytics."
+homepage = "https://duckdb.org"
+documentation = "https://github.com/duckdb/pg_duckdb/tree/main/docs"
+categories = ['analytics']
+
+[build]
+postgres_version = "17"
+platform = "linux/amd64"
+dockerfile = "Dockerfile"
+install_command = "make -C pg_duckdb install"


### PR DESCRIPTION
The former relies on the DuckDB DSO, included in the updated trunk-test-tembo image. The latter is all Rust so requires no other dependencies.