### PR TITLE
Always download DuckDB DSO

### DIFF
--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -57,7 +57,7 @@ jobs:
       - dind
       - xlarge-16x16
     container:
-      image: quay.io/tembo/trunk-test-tembo:73092d1-pg15
+      image: quay.io/tembo/trunk-test-tembo:4436f19-pg15
       options: --user root
     needs:
       - find_directories
@@ -92,7 +92,7 @@ jobs:
       - dind
       - xlarge-16x16
     container:
-      image: quay.io/tembo/trunk-test-tembo:73092d1-pg15
+      image: quay.io/tembo/trunk-test-tembo:4436f19-pg15
       options: --user root
     needs:
       - find_directories
@@ -167,7 +167,7 @@ jobs:
             fi
           done
       - name: Enable the extension
-        if: matrix.pg == 15 && github.ref != 'refs/heads/main'
+        if: matrix.pg == 15 && github.ref != 'refs/heads/main' && matrix.ext.name != 'duckdb_fdw' # https://github.com/duckdb/pg_duckdb/issues/554
         run: |
           su postgres -c '/usr/lib/postgresql/15/bin/postgres &'
           sleep 5

--- a/contrib/duckdb_fdw/Dockerfile
+++ b/contrib/duckdb_fdw/Dockerfile
@@ -1,19 +1,17 @@
 ARG PG_VERSION=17
+# Set up image to copy libduckdb from.
+FROM quay.io/tembo/standard-cnpg:${PG_VERSION}-f9c2075 AS std
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Download and install the DuckDB DSO.
-ARG EXTENSION_VERSION
-ENV DUCKDB_VERSION=${EXTENSION_VERSION}
+# Copy the DuckDB DSO.
 USER root
-# Funky naming expectations: https://github.com/alitrack/duckdb_fdw/issues/64
-RUN curl -LO https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/libduckdb-linux-amd64.zip \
-    && unzip -d . libduckdb-linux-amd64.zip \
-    && install -m 755 libduckdb.so "/usr/local/lib/libduckdb.${DUCKDB_VERSION}.so" \
-    && (cd /usr/local/lib && ln -s "libduckdb.${DUCKDB_VERSION}.so" "libduckdb.so")
+COPY --from=std "/usr/local/lib/libduckdb.*.so" /usr/local/lib
+RUN cd /usr/local/lib && ln -s "libduckdb.*.so" "libduckdb.so"
 
 # Clone and build the extension.
 ARG EXTENSION_NAME
 ARG EXTENSION_VERSION
+ENV DUCKDB_VERSION=1.1.3
 RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/alitrack/${EXTENSION_NAME}.git \
     && perl -i -pe 's/^install:/#/' "${EXTENSION_NAME}/Makefile" \
     && make -C ${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/mobilitydb/Dockerfile
+++ b/contrib/mobilitydb/Dockerfile
@@ -1,6 +1,6 @@
 ARG PG_VERSION
 # Set up image to copy trunk from.
-FROM quay.io/tembo/trunk-test-tembo:73092d1-pg15 AS trunk
+FROM quay.io/tembo/trunk-test-tembo:4436f19-pg15 AS trunk
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
 USER root

--- a/contrib/pg_duckdb/Dockerfile
+++ b/contrib/pg_duckdb/Dockerfile
@@ -24,6 +24,4 @@ RUN apt-get update && \
 ARG EXTENSION_NAME
 ARG EXTENSION_VERSION
 RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/duckdb/${EXTENSION_NAME}.git \
-    && cd ${EXTENSION_NAME} \
-    && git submodule update --depth 1 --init --recursive \
-    && make
+    && make -C ${EXTENSION_NAME}

--- a/contrib/pg_duckdb/Trunk.toml
+++ b/contrib/pg_duckdb/Trunk.toml
@@ -1,12 +1,13 @@
 [extension]
 name = "pg_duckdb"
-version = "0.2.0"
+version = "0.2.0" # Update tembo-images/standard-cnpg/Dockerfile, too.
 repository = "https://github.com/duckdb/pg_duckdb"
 license = "MIT"
 description = "DuckDB-powered Postgres for high performance apps & analytics."
 homepage = "https://duckdb.org"
 documentation = "https://github.com/duckdb/pg_duckdb/tree/main/docs"
 categories = ['analytics']
+loadable_libraries = [{ library_name = "pg_duckdb", requires_restart = true }]
 
 [build]
 postgres_version = "17"


### PR DESCRIPTION
Rather than letting the Git repo build it from a submodule. Otherwise the pg_duckdb builder installs it into the Postgres lib directory, which isn't included in `ld`'s path, so Postgres can't find it. Update to `trunk-test-tembo:4436f19`, which includes the supported version of `libduckdb.so`.

Also configure it to be added to `shared_preload_libraries` and needing to restart.

Copy the same `libduckdb.so` to build `duckdb_fdw`, too, and explicitly set its version, since it may diverge from `duckdb_fdw`'s own version. The build is successful, but `duckdb_fdw` does not load with the `libduckdb.so` built by `pg_duckdb`, so skip testing it for now. Will fix once duckdb/pg_duckdb#554 or its successor resolves thing such that both extensions can use the same DSO.