### PR TITLE
Base trunk-test-tembo on latest standard-cnpg

### DIFF
--- a/.github/workflows/test-images.yml
+++ b/.github/workflows/test-images.yml
@@ -28,7 +28,7 @@ jobs:
       - large-8x8
     strategy:
       matrix:
-        pg_version: ["14", "15", "16"]
+        pg_version: ["14", "15", "16", "17"]
     outputs:
       short_sha: ${{ steps.versions.outputs.SHORT_SHA }}
     steps:

--- a/images/trunk-test-tembo/Dockerfile
+++ b/images/trunk-test-tembo/Dockerfile
@@ -1,27 +1,14 @@
 ARG PG_VERSION=15
-ARG TAG=latest
+ARG TAG=7ae38e9
 
-FROM rust:1.82-bookworm as builder
+FROM quay.io/tembo/standard-cnpg:${PG_VERSION}-${TAG}
 
-ARG TRUNK_VER=0.15.10
-
-ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL sparse
-RUN cargo install --version $TRUNK_VER pg-trunk
-
-FROM quay.io/tembo/standard-cnpg:${PG_VERSION}-f9c2075
-
-# Install trunk
-COPY --from=builder /usr/local/cargo/bin/trunk /usr/bin/trunk
-
+# Install extension dependencies
 USER root
 RUN apt-get update && apt-get install -y \
     jq \
     curl \
     wget \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install extension dependencies
-RUN apt-get update && apt-get install -y \
     libmysqlclient-dev \
     libtcl8.6 \
     libgeos-dev \
@@ -59,27 +46,7 @@ RUN apt-get update && apt-get install -y \
     libaio1 \
     libbson-dev \
     libgsl-dev \
-    && apt-get purge -y --auto-remove libgroonga0 \
     && rm -rf /var/lib/apt/lists/*
-
-# Install zhparser dependency
-RUN  wget http://www.xunsearch.com/scws/down/scws-1.2.3.tar.bz2 && \
-     tar xvf scws-1.2.3.tar.bz2 && \
-     cd scws-1.2.3 && \
-     ./configure && \
-     make install && \
-     cd .. && \
-     rm -rf scws-1.2.3.tar.bz2 scws-1.2.3 && \
-     ln -s /usr/local/lib/libscws.so /usr/lib/x86_64-linux-gnu/libscws.so
-
-# Install groonga libs
-RUN wget https://packages.groonga.org/source/groonga/groonga-14.1.2.tar.gz \
-    && tar xvzf groonga-14.1.2.tar.gz \
-    && cd groonga-14.1.2 \
-    && ./configure \
-    && make -j$(grep '^processor' /proc/cpuinfo | wc -l) \
-    && make install \
-    && cd .. && rm -rf groonga-14.1.2*
 
 RUN chown -R postgres:postgres $PGDATA && \
     chmod -R 0700 $PGDATA


### PR DESCRIPTION
Th standard-cnpg image includes `libduckdb.so`, `groonga`, and Trunk, so there is no reason to install them all. Also remove `scws`, as no extension currently depends on it. Finally, merge the two `apt-get` commands into a single `RUN` statement.