### PR TITLE
Upgrade pgrouting to v3.7.2

### DIFF
--- a/contrib/pgrouting/Dockerfile
+++ b/contrib/pgrouting/Dockerfile
@@ -13,5 +13,7 @@ RUN apt-get update && apt-get install -y \
 ARG EXTENSION_NAME
 ARG EXTENSION_VERSION
 RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/${EXTENSION_NAME}/${EXTENSION_NAME}.git \
+    # https://github.com/pgRouting/pgrouting/pull/2728/files
+    && perl -i -pe 's/cmake_policy\(SET CMP0148 OLD\)/if(POLICY CMP0148)\n    cmake_policy(SET CMP0148 OLD)\nendif()/' ${EXTENSION_NAME}/CMakeLists.txt \
     && cmake -S ${EXTENSION_NAME} -B ${EXTENSION_NAME}/build \
     && make -C ${EXTENSION_NAME}/build -j8

--- a/contrib/pgrouting/Trunk.toml
+++ b/contrib/pgrouting/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pgrouting"
-version = "3.7.1"
+version = "3.7.2"
 repository = "https://github.com/pgRouting/pgrouting"
 license = "GPL-2.0"
 description = "pgRouting extends the PostGIS / PostgreSQL geospatial database to provide geospatial routing functionality."


### PR DESCRIPTION
Requires a patch to compile; should be able to remove it following the next release, thanks to pgRouting/pgrouting#2728.