### PR TITLE
Build duckdb_fdw with libduckdb 1.2.0 (#)

### DIFF
--- a/contrib/duckdb_fdw/Dockerfile
+++ b/contrib/duckdb_fdw/Dockerfile
@@ -1,6 +1,6 @@
 ARG PG_VERSION=17
-# Set up image to copy libduckdb from.
-FROM quay.io/tembo/standard-cnpg:${PG_VERSION}-f9c2075 AS std
+# Set up image from which to copy libduckdb-1.2.0.
+FROM quay.io/tembo/standard-cnpg:${PG_VERSION}-ff3c954 AS std
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
 # Copy the DuckDB DSO.
@@ -11,7 +11,7 @@ RUN cd /usr/local/lib && ln -s "libduckdb.*.so" "libduckdb.so"
 # Clone and build the extension.
 ARG EXTENSION_NAME
 ARG EXTENSION_VERSION
-ENV DUCKDB_VERSION=1.1.3
+ENV DUCKDB_VERSION=1.2.0
 RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/alitrack/${EXTENSION_NAME}.git \
     && perl -i -pe 's/^install:/#/' "${EXTENSION_NAME}/Makefile" \
     && make -C ${EXTENSION_NAME} USE_PGXS=1


### PR DESCRIPTION
Uses the `libduckdb.so` built by pg_duckdb 0.3.1, now available on Trunk.