### PR TITLE
Use official libduckdb release with duckdb_fdw (#933)

### DIFF
--- a/.github/workflows/extensions.yaml
+++ b/.github/workflows/extensions.yaml
@@ -57,7 +57,7 @@ jobs:
       - dind
       - xlarge-16x16
     container:
-      image: quay.io/tembo/trunk-test-tembo:4436f19-pg15
+      image: quay.io/tembo/trunk-test-tembo:4436f19-pg${{ matrix.pg }}
       options: --user root
     needs:
       - find_directories
@@ -92,7 +92,7 @@ jobs:
       - dind
       - xlarge-16x16
     container:
-      image: quay.io/tembo/trunk-test-tembo:4436f19-pg15
+      image: quay.io/tembo/trunk-test-tembo:4436f19-pg${{ matrix.pg }}
       options: --user root
     needs:
       - find_directories
@@ -149,6 +149,19 @@ jobs:
           set -xe
           apt-get update
           apt-get install -y pkg-config libssl-dev gosu openjdk-11-jdk
+      - name: Install libduckdb
+        if: matrix.ext.name == 'duckdb_fdw'
+        # duckdb_fdw is incompatible with the pg_duckdb-build libduckdb.so included in
+        # the standard image. So replace it.
+        env:
+          DUCKDB_VERSION: 1.2.0
+        run: |
+          set -xe
+          rm -rf "$(pg_config --pkglibdir)/libduckdb*" /usr/local/lib/libduckdb*
+          curl -LO https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/libduckdb-linux-amd64.zip
+          unzip libduckdb-linux-amd64.zip libduckdb.so
+          mv libduckdb.so /usr/local/lib/libduckdb.so.${DUCKDB_VERSION}
+          ldconfig
       - name: Build extension
         id: build
         run: cd ${{ matrix.ext.path }} && trunk build --pg-version ${{ matrix.pg }}
@@ -167,9 +180,9 @@ jobs:
             fi
           done
       - name: Enable the extension
-        if: matrix.pg == 15 && github.ref != 'refs/heads/main' && matrix.ext.name != 'duckdb_fdw' # https://github.com/duckdb/pg_duckdb/issues/554
+        if: matrix.pg == 15 && github.ref != 'refs/heads/main'
         run: |
-          su postgres -c '/usr/lib/postgresql/15/bin/postgres &'
+          su postgres -c '/usr/lib/postgresql/${{ matrix.pg }}/bin/postgres &'
           sleep 5
           export EXTENSIONS=$(psql postgres://postgres:postgres@localhost:5432 -tA -c "select name from pg_available_extensions where name NOT IN ('plpgsql', 'plperlu', 'plperl', 'pltcl', 'plpython3u', 'pltclu', 'pg_stat_statements', 'pgml')";)
           for EXTENSION in $EXTENSIONS; do

--- a/contrib/duckdb_fdw/Dockerfile
+++ b/contrib/duckdb_fdw/Dockerfile
@@ -1,17 +1,19 @@
 ARG PG_VERSION=17
-# Set up image from which to copy libduckdb-1.2.0.
-FROM quay.io/tembo/standard-cnpg:${PG_VERSION}-ff3c954 AS std
 FROM quay.io/coredb/c-builder:pg${PG_VERSION}
 
-# Copy the DuckDB DSO.
+# Install libduckdb and create the funky name that duckdb_fdw's Makefile wants at compile time.
 USER root
-COPY --from=std "/usr/local/lib/libduckdb.*.so" /usr/local/lib
-RUN cd /usr/local/lib && ln -s "libduckdb.*.so" "libduckdb.so"
-
-# Clone and build the extension.
+ENV DUCKDB_VERSION=1.2.0
 ARG EXTENSION_NAME
 ARG EXTENSION_VERSION
-ENV DUCKDB_VERSION=1.2.0
-RUN git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/alitrack/${EXTENSION_NAME}.git \
+    # Download and install libduckdb.so
+RUN curl -LO https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/libduckdb-linux-amd64.zip \
+    && unzip libduckdb-linux-amd64.zip libduckdb.so \
+    && mv libduckdb.so /usr/local/lib/libduckdb.so.${DUCKDB_VERSION} \
+    && ldconfig \
+    # Create the silly file name the Makefile wants.
+    && (cd /usr/local/lib && ln -s "libduckdb.so.${DUCKDB_VERSION}" libduckdb.${DUCKDB_VERSION}.so) \
+    # Clone the repo, remove the useless `install` target, and build
+    && git clone --depth 1 --branch "v${EXTENSION_VERSION}" https://github.com/alitrack/${EXTENSION_NAME}.git \
     && perl -i -pe 's/^install:/#/' "${EXTENSION_NAME}/Makefile" \
     && make -C ${EXTENSION_NAME} USE_PGXS=1

--- a/contrib/duckdb_fdw/Trunk.toml
+++ b/contrib/duckdb_fdw/Trunk.toml
@@ -8,6 +8,9 @@ homepage = "https://alitrack.com/"
 documentation = "https://github.com/alitrack/duckdb_fdw"
 categories = ['connectors']
 
+[dependencies]
+lib = ["libduckdb"]
+
 [build]
 postgres_version = "17"
 platform = "linux/amd64"


### PR DESCRIPTION
Rather than copying it from the `pg_duckdb` trunk, which is customized and breaks `duckdb_fdw`. Which is super weird, because it builds, but then fails to load with a missing symbol error.

So install `libduckdb.so` with its proper version and run `ldconfig`, both in the `Dockerfile` and in the test workflow. Add it as a `lib` dependency to the `Trunk.toml`.

While at it, use the matrix Postgres version instead of a hard-coded `15` in the workflow.