### PR TITLE
Truncate dynamic lang Apt package names

### DIFF
--- a/contrib/bool_plperl/Trunk.toml
+++ b/contrib/bool_plperl/Trunk.toml
@@ -9,7 +9,7 @@ documentation = "https://www.postgresql.org/docs/current/plperl-funcs.html"
 categories = ["data_transformations"]
 
 [dependencies]
-apt = ["libperl5.34", "libc6"]
+apt = ["libperl5", "libc6"]
 
 [build]
 postgres_version = "17"

--- a/contrib/bool_plperlu/Trunk.toml
+++ b/contrib/bool_plperlu/Trunk.toml
@@ -9,7 +9,7 @@ documentation = "https://www.postgresql.org/docs/current/plperl-funcs.html"
 categories = ["data_transformations"]
 
 [dependencies]
-apt = ["libperl5.34", "libc6"]
+apt = ["libperl5", "libc6"]
 
 [build]
 postgres_version = "17"

--- a/contrib/hstore_plperl/Trunk.toml
+++ b/contrib/hstore_plperl/Trunk.toml
@@ -9,7 +9,7 @@ documentation = "https://www.postgresql.org/docs/current/hstore.html"
 categories = ["data_transformations"]
 
 [dependencies]
-apt = ["libc6", "libperl5.34"]
+apt = ["libc6", "libperl5"]
 
 [build]
 postgres_version = "17"

--- a/contrib/hstore_plperlu/Trunk.toml
+++ b/contrib/hstore_plperlu/Trunk.toml
@@ -9,7 +9,7 @@ documentation = "https://www.postgresql.org/docs/current/hstore.html"
 categories = ["data_transformations"]
 
 [dependencies]
-apt = ["libc6", "libperl5.34"]
+apt = ["libc6", "libperl5"]
 
 [build]
 postgres_version = "17"

--- a/contrib/hstore_plpython/Trunk.toml
+++ b/contrib/hstore_plpython/Trunk.toml
@@ -9,7 +9,7 @@ documentation = "https://www.postgresql.org/docs/current/hstore.html"
 categories = ["data_transformations"]
 
 [dependencies]
-apt = ["libc6", "libpython3.10"]
+apt = ["libc6", "libpython3"]
 
 [build]
 postgres_version = "17"

--- a/contrib/jsonb_plperl/Trunk.toml
+++ b/contrib/jsonb_plperl/Trunk.toml
@@ -9,7 +9,7 @@ documentation = "https://www.postgresql.org/docs/current/datatype-json.html"
 categories = ["data_transformations"]
 
 [dependencies]
-apt = ["libc6", "libperl5.34"]
+apt = ["libc6", "libperl5"]
 
 [build]
 postgres_version = "17"

--- a/contrib/jsonb_plpython/Trunk.toml
+++ b/contrib/jsonb_plpython/Trunk.toml
@@ -9,7 +9,7 @@ documentation = "https://www.postgresql.org/docs/current/datatype-json.html"
 categories = ["data_transformations"]
 
 [dependencies]
-apt = ["libc6", "libpython3.10"]
+apt = ["libc6", "libpython3"]
 
 [build]
 postgres_version = "17"

--- a/contrib/moddatetime/Trunk.toml
+++ b/contrib/moddatetime/Trunk.toml
@@ -9,7 +9,7 @@ documentation = "https://www.postgresql.org/docs/current/contrib-spi.html"
 categories = ["auditing_logging"]
 
 [dependencies]
-apt = ["libc6", "libpython3.10"]
+apt = ["libc6", "libpython3"]
 
 [build]
 postgres_version = "17"

--- a/contrib/plperl/Trunk.toml
+++ b/contrib/plperl/Trunk.toml
@@ -9,7 +9,7 @@ documentation = "https://www.postgresql.org/docs/current/plperl.html"
 categories = ["procedural_languages"]
 
 [dependencies]
-apt = ["libc6", "libperl5.34"]
+apt = ["libc6", "libperl5"]
 
 [build]
 postgres_version = "17"

--- a/contrib/plperlu/Trunk.toml
+++ b/contrib/plperlu/Trunk.toml
@@ -9,7 +9,7 @@ documentation = "https://www.postgresql.org/docs/current/plperl-trusted.html"
 categories = ["procedural_languages"]
 
 [dependencies]
-apt = ["libc6", "libperl5.34"]
+apt = ["libc6", "libperl5"]
 
 [build]
 postgres_version = "17"

--- a/contrib/plpython3u/Trunk.toml
+++ b/contrib/plpython3u/Trunk.toml
@@ -9,7 +9,7 @@ documentation = "https://www.postgresql.org/docs/current/plpython.html"
 categories = ["procedural_languages"]
 
 [dependencies]
-apt = ["libc6", "libpython3.10"]
+apt = ["libc6", "libpython3"]
 
 [build]
 postgres_version = "17"

--- a/contrib/pltcl/Trunk.toml
+++ b/contrib/pltcl/Trunk.toml
@@ -9,7 +9,7 @@ documentation = "https://www.postgresql.org/docs/current/pltcl.html"
 categories = ["procedural_languages"]
 
 [dependencies]
-apt = ["libtcl8.6.so", "libc6"]
+apt = ["libtcl8", "libc6"]
 
 [build]
 postgres_version = "17"

--- a/contrib/pltclu/Trunk.toml
+++ b/contrib/pltclu/Trunk.toml
@@ -9,7 +9,7 @@ documentation = "https://www.postgresql.org/docs/current/pltcl-overview.html"
 categories = ["procedural_languages"]
 
 [dependencies]
-apt = ["libtcl8.6.so", "libc6"]
+apt = ["libtcl8", "libc6"]
 
 [build]
 postgres_version = "17"

--- a/contrib/postgresml/Trunk.toml
+++ b/contrib/postgresml/Trunk.toml
@@ -10,7 +10,7 @@ loadable_libraries = [{ library_name = "pgml", requires_restart = true }]
 categories = ["machine_learning"]
 
 [dependencies]
-apt = ["libpython3.10", "libstdc++6", "libgomp1", "libopenblas0-pthread", "libc6", "libgcc-s1"]
+apt = ["libpython3", "libstdc++6", "libgomp1", "libopenblas0-pthread", "libc6", "libgcc-s1"]
 pip = ["xgboost"]
 
 [build]


### PR DESCRIPTION
The versions differ for different versions of Debian/Ubuntu. So shorten to just the major version. Installers will have to determine what's the latest version for a given OS.