### PR TITLE
Release CLI on tag rather than push to main

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -6,12 +6,14 @@ on:
       - "cli/**"
       - "!cli/README.md"
       - "!cli/.gitignore"
+    tags: ["**"]
 permissions:
   contents: write
 defaults:
   run:
     shell: bash
     working-directory: ./cli/
+
 jobs:
   release:
     name: 🦀 ${{ matrix.toolchain }} on linux/${{ matrix.arch }}
@@ -51,13 +53,20 @@ jobs:
           cp target/release/trunk "$ARCHIVE"/
           cp {README.md,../LICENSE} "$ARCHIVE"/
           tar czvf "$ARCHIVE.tar.gz" "$ARCHIVE"
+      - name: Check the Version
+        run: |
+          if [ "${{ github.ref_name }}" != "v$VERSION" ]; then
+              printf "Cargo.toml version %s does not match tag %s\n" "$VERSION" "${{ github.ref_name }}" >&2
+              exit 1
+          fi
+        if: matrix.toolchain == 'stable' && startsWith( github.ref, 'refs/tags/v' )
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           path: cli/${{ env.ARCHIVE }}.*
           name: ${{ env.ARCHIVE }}
           overwrite: true
-        if: matrix.toolchain == 'stable' && github.ref_name == 'main'
+        if: matrix.toolchain == 'stable' && startsWith( github.ref, 'refs/tags/v' )
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -65,4 +74,4 @@ jobs:
           name: Trunk ${{ env.VERSION }}
           body: Trunk ${{ env.VERSION }} builds for amd64 and arm64 Linux.
           files: cli/${{ env.ARCHIVE }}.*
-        if: matrix.toolchain == 'stable' && github.ref_name == 'main'
+        if: matrix.toolchain == 'stable' && startsWith( github.ref, 'refs/tags/v' )

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -115,3 +115,12 @@ jobs:
           dry-run: ${{ steps.cargo_flags.outputs.dry_run }}
           fail-if-version-published: ${{ steps.cargo_flags.outputs.fail_if_version_published }}
           cargo-registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      # Alas this does not work. https://github.com/orgs/community/discussions/27028
+      # - name: Tag Release
+      #   # if: ${{ !steps.cargo_flags.outputs.dry_run }}
+      #   run: |
+      #     git config --global user.name "coredb-service-user"
+      #     git config --global user.email "admin+github@coredb.io"
+      #     TAG="cli-v$(grep "^version" Cargo.toml | sed -r 's/version[^"]+"([^"]+).*/\1/')"
+      #     git tag -a "$TAG" -m "Tag $TAG"
+      #     git push origin "$TAG"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.16.6"
+version = "0.16.7"
 edition = "2021"
 authors = ["Ian Stanton", "Vinícius Miguel", "David E. Wheeler"]
 description = "A package manager for PostgreSQL extensions"


### PR DESCRIPTION
The `cli.yml` workflow publishes to crates.io on eery every push to main. But that doesn't work for releasing on GitHub, because GitHub releases require a tag, and as the comment in `cli.yml` reports, pushing a tag from a workflow does not trigger other workflows.

So change the CLI release process to require a tag. Validate that the tag matches the version in `cli/Cargo.toml`. This means we'll need to be diligent about tagging CLI releases, as they can't be automated in the same way as `cargo publish`.