### PR TITLE
Update pg_stat_monitor to 2.1.1

### DIFF
--- a/contrib/pg_stat_monitor/Trunk.toml
+++ b/contrib/pg_stat_monitor/Trunk.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "pg_stat_monitor"
-version = "2.1.0"
+version = "2.1.1"
 repository = "https://github.com/percona/pg_stat_monitor"
 license = "PostgreSQL"
 description = "Query Performance Monitoring Tool for PostgreSQL."


### PR DESCRIPTION
This PR updates [pg_stat_monitor](https://github.com/percona/pg_stat_monitor) to [2.1.1](https://github.com/percona/pg_stat_monitor/releases/tag/2.1.1) version.