### PR TITLE
Remove arch from Rust cache-key

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -2,11 +2,19 @@ name: 🚀 Release Trunk
 on:
   push:
     paths:
-      - ".github/workflows/cli-release.yml"
+      - ".github/workflows/cli*.yml"
       - "cli/**"
       - "!cli/README.md"
       - "!cli/.gitignore"
     tags: ["**"]
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/cli*.yml"
+      - "cli/**"
+      - "!cli/README.md"
+      - "!cli/.gitignore"
 permissions:
   contents: write
 defaults:
@@ -35,7 +43,6 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
-          cache-key: ${{ matrix.arch }}
           components: rustfmt, clippy, llvm-tools
       - name: Build Binary
         run: cargo build --release

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
     paths:
-      - ".github/workflows/cli.yml"
+      - ".github/workflows/cli*.yml"
       - "cli/**"
       - "!cli/README.md"
       - "!cli/.gitignore"
@@ -18,7 +18,7 @@ on:
     branches:
       - main
     paths:
-      - ".github/workflows/cli.yml"
+      - ".github/workflows/cli*.yml"
       - "cli/**"
       - "!cli/README.md"
       - "!cli/.gitignore"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.16.7"
+version = "0.16.8"
 edition = "2021"
 authors = ["Ian Stanton", "Vinícius Miguel", "David E. Wheeler"]
 description = "A package manager for PostgreSQL extensions"


### PR DESCRIPTION
The Rust setup action already includes the OS and architecture in the key, so no need to add it.

Increment to v0.16.8, as the v0.16.7 release included an arm64 binary in the amd64 artifact, likely due to a cache hit for a previous incorrect build.

Also trigger builds in pull requests targeting the main branch.