### PR TITLE
Build binaries on jammy (glibc 2.35)

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -25,12 +25,8 @@ defaults:
 jobs:
   release:
     name: 🦀 ${{ matrix.toolchain }} on linux/${{ matrix.arch }}
-    runs-on:
-      # https://runs-on.com/runners/linux/
-      - runs-on=${{ github.run_id }}-${{ matrix.toolchain }}-${{ matrix.arch }}
-      - runner=large-${{ matrix.arch }}
-      - cpu=8
-      - ram=16
+    # Build on older generation for better libc compatibility.
+    runs-on: ubuntu-22.04${{ matrix.arch == 'arm64' && '-arm' || '' }}
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     strategy:
       fail-fast: false

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.16.8"
+version = "0.16.9"
 edition = "2021"
 authors = ["Ian Stanton", "Vinícius Miguel", "David E. Wheeler"]
 description = "A package manager for PostgreSQL extensions"


### PR DESCRIPTION
Which lets them work with glibc 2.35 and higher, rather than 2.39. The previous building on noble with glibc 2.39 prevented it from executing at all on noble.

Increment to v0.16.9 to release.