### PR TITLE
Add `--strip-libdir` option

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.16.9"
+version = "0.17.0"
 edition = "2021"
 authors = ["Ian Stanton", "Vinícius Miguel", "David E. Wheeler"]
 description = "A package manager for PostgreSQL extensions"


### PR DESCRIPTION
Required for PostgreSQL 17 and earlier to be able to find extension shared modules when they're not installed in the default library dir. IOW, when they're in a directory listed in `dynamic_library_path`.

Closes TEM-3529.