### PR TITLE
Do not deploy to staging environment

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -173,9 +173,6 @@ jobs:
             subdirectory: dev
             branch: main
           - repository: tembo-io/app-deploy
-            subdirectory: staging
-            branch: staging-updates
-          - repository: tembo-io/app-deploy
             subdirectory: prod
             branch: prod-updates
     needs:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @EvanHStanton @ianstanton @theory @vrmiguel @ChuckHend
-/ui/ @aishwaryaborkar @DarrenBaldwin07 @sarahedkins @vrmiguel
+* @theory @vrmiguel
+/ui/ @DarrenBaldwin07 @vrmiguel

--- a/registry/src/readme.rs
+++ b/registry/src/readme.rs
@@ -232,7 +232,7 @@ impl<'a> GitHubProject<'a> {
             let owner = parts.next()?;
             let name = parts.next()?;
             let subdir = if let Some("tree") = parts.next() {
-                parts.last()
+                parts.next_back()
             } else {
                 None
             };


### PR DESCRIPTION
We no longer need to deploy this project to our staging environment. 

- Linear: [TEM-3624](https://linear.app/tembo/issue/TEM-3621/update-tembo-metrics-repo-to-not-deploy-to-plat-staging)