### PR TITLE
do not deploy to dev

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -169,9 +169,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - repository: tembo-io/app-deploy-dev
-            subdirectory: dev
-            branch: main
           - repository: tembo-io/app-deploy
             subdirectory: prod
             branch: prod-updates


### PR DESCRIPTION
There is not a dev deployment for trunk anymore, so remove the option to deploy it there